### PR TITLE
Implement BakedModel wireframe rendering 

### DIFF
--- a/src/main/java/com/dimensiondelvers/dimensiondelvers/client/render/ModelWireframeExtractor.java
+++ b/src/main/java/com/dimensiondelvers/dimensiondelvers/client/render/ModelWireframeExtractor.java
@@ -1,0 +1,151 @@
+package com.dimensiondelvers.dimensiondelvers.client.render;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import net.minecraft.MethodsReturnNonnullByDefault;
+import net.minecraft.client.renderer.RenderType;
+import net.minecraft.client.renderer.block.model.BakedQuad;
+import net.minecraft.client.resources.model.BakedModel;
+import net.minecraft.core.Direction;
+import net.minecraft.util.RandomSource;
+import net.minecraft.world.level.block.state.BlockState;
+import net.neoforged.neoforge.client.model.IQuadTransformer;
+import net.neoforged.neoforge.client.model.data.ModelData;
+import org.jetbrains.annotations.Nullable;
+import org.joml.Math;
+import org.joml.Vector3f;
+
+/**
+ * Utility class for extracting wireframe outlines from a {@link BakedModel}.
+ * This is used to generate visual outlines.
+ */
+public class ModelWireframeExtractor {
+
+    /**
+     * Extracts the wireframe lines from a given block model.
+     *
+     * @param model      The baked model of the block.
+     * @param state      The block state (nullable).
+     * @param rand       A random source for generating variations.
+     * @param modelData  Model data for the block.
+     * @param renderType The render type (nullable).
+     * @return A list of {@link RenderLine} objects representing the wireframe.
+     */
+    public static List<RenderLine> extract(BakedModel model, @Nullable BlockState state, RandomSource rand, ModelData modelData, @Nullable RenderType renderType) {
+        Set<RenderLine> lines = new HashSet<>();
+        QuadVertexProcessor extractor = new QuadVertexProcessor(lines);
+        for (Direction direction : Direction.values()) {
+            for (BakedQuad quad : model.getQuads(state, direction, rand, modelData, renderType)) {
+                extractor.unpack(quad);
+            }
+        }
+
+        for (BakedQuad quad : model.getQuads(state, null, rand, modelData, renderType)) {
+            extractor.unpack(quad);
+        }
+        return new ArrayList<>(lines);
+    }
+
+    // Modified version of VertexConsumer
+    @MethodsReturnNonnullByDefault
+    private static class QuadVertexProcessor {
+        final Set<RenderLine> lines;
+        final Vector3f[] vertices = new Vector3f[4];
+        int vertexIndex = 0;
+
+        private QuadVertexProcessor(Set<RenderLine> lines) {
+            this.lines = lines;
+        }
+
+        /**
+         * Adds a vertex to the current quad. Once four vertices are added, the quad is converted into four lines.
+         *
+         * @param pX X coordinate of the vertex.
+         * @param pY Y coordinate of the vertex.
+         * @param pZ Z coordinate of the vertex.
+         */
+         public void vertex(float pX, float pY, float pZ) {
+            vertices[vertexIndex++] = new Vector3f(pX, pY, pZ);
+            if (vertexIndex == 4) {
+                vertexIndex = 0;
+                lines.add(RenderLine.from(vertices[0], vertices[1]));
+                lines.add(RenderLine.from(vertices[1], vertices[2]));
+                lines.add(RenderLine.from(vertices[2], vertices[3]));
+                lines.add(RenderLine.from(vertices[3], vertices[0]));
+                Arrays.fill(vertices, null);
+            }
+        }
+
+        /**
+         * Extracts vertex positions from a given {@link BakedQuad}.
+         *
+         * @param pQuad The baked quad to extract from.
+         */
+        public void unpack(BakedQuad pQuad) {
+            int[] quadVertices = pQuad.getVertices();
+            for (int i = 0; i < 4; i++) {
+                int offset = i * IQuadTransformer.STRIDE + IQuadTransformer.POSITION;
+                float x = Float.intBitsToFloat(quadVertices[offset]);
+                float y = Float.intBitsToFloat(quadVertices[offset + 1]);
+                float z = Float.intBitsToFloat(quadVertices[offset + 2]);
+                this.vertex(x, y, z);
+            }
+        }
+    }
+
+    /**
+     * Represents a line segment in 3D space, used for wireframe rendering.
+     *
+     * @param x1  X coordinate of the first point.
+     * @param y1  Y coordinate of the first point.
+     * @param z1  Z coordinate of the first point.
+     * @param x2  X coordinate of the second point.
+     * @param y2  Y coordinate of the second point.
+     * @param z2  Z coordinate of the second point.
+     * @param nX  Normalized X direction of the line.
+     * @param nY  Normalized Y direction of the line.
+     * @param nZ  Normalized Z direction of the line.
+     * @param hash Precomputed hash code for faster lookup.
+     */
+    public record RenderLine(float x1, float y1, float z1, float x2, float y2, float z2, float nX, float nY, float nZ, int hash) {
+
+        /**
+         * Creates a new {@link RenderLine} from two 3D points.
+         *
+         * @param v1 The first point.
+         * @param v2 The second point.
+         * @return A new {@link RenderLine} object.
+         */
+        public static RenderLine from(Vector3f v1, Vector3f v2) {
+            float nX = v2.x - v1.x;
+            float nY = v2.y - v1.y;
+            float nZ = v2.z - v1.z;
+            float scalar = Math.invsqrt(Math.fma(nX, nX, Math.fma(nY, nY, nZ * nZ)));
+
+            nX = nX * scalar;
+            nY = nY * scalar;
+            nZ = nZ * scalar;
+
+            return new RenderLine(v1.x, v1.y, v1.z, v2.x, v2.y, v2.z, nX, nY, nZ, calculateHash(v1.x, v1.y, v1.z, v2.x, v2.y, v2.z));
+        }
+
+        private static int calculateHash(float x1, float y1, float z1, float x2, float y2, float z2) {
+            int result = Long.hashCode((long) Math.min(x1, x2) * 3200);
+            result = 31 * result + Long.hashCode((long) Math.min(y1, y2) * 3200);
+            result = 31 * result + Long.hashCode((long) Math.min(z1, z2) * 3200);
+            result = 31 * result + Long.hashCode((long) Math.max(x1, x2) * 3200);
+            result = 31 * result + Long.hashCode((long) Math.max(y1, y2) * 3200);
+            result = 31 * result + Long.hashCode((long) Math.max(z1, z2) * 3200);
+            return result;
+        }
+
+        @Override
+        public int hashCode() {
+            return hash;
+        }
+    }
+}
+

--- a/src/main/java/com/dimensiondelvers/dimensiondelvers/events/RenderEvents.java
+++ b/src/main/java/com/dimensiondelvers/dimensiondelvers/events/RenderEvents.java
@@ -1,0 +1,115 @@
+package com.dimensiondelvers.dimensiondelvers.events;
+
+import com.dimensiondelvers.dimensiondelvers.DimensionDelvers;
+import com.dimensiondelvers.dimensiondelvers.client.render.ModelWireframeExtractor;
+import com.mojang.blaze3d.vertex.PoseStack;
+import com.mojang.blaze3d.vertex.VertexConsumer;
+import it.unimi.dsi.fastutil.objects.Reference2ObjectOpenHashMap;
+import net.minecraft.client.Camera;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.RenderType;
+import net.minecraft.client.resources.model.BakedModel;
+import net.minecraft.core.BlockPos;
+import net.minecraft.util.RandomSource;
+import net.minecraft.util.profiling.ProfilerFiller;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.phys.BlockHitResult;
+import net.minecraft.world.phys.HitResult;
+import net.minecraft.world.phys.Vec3;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.client.event.RenderHighlightEvent;
+import net.neoforged.neoforge.client.model.data.ModelData;
+import org.joml.Matrix3f;
+import org.joml.Matrix4f;
+import org.joml.Vector3f;
+import org.joml.Vector4f;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+@EventBusSubscriber(modid = DimensionDelvers.MODID, value = Dist.CLIENT, bus = EventBusSubscriber.Bus.GAME)
+public class RenderEvents {
+    private static final Minecraft minecraft = Minecraft.getInstance();
+    private static final Map<BlockState, List<ModelWireframeExtractor.RenderLine>> cachedWireFrames = new Reference2ObjectOpenHashMap<>();
+
+
+    public static void resetCached() {
+        cachedWireFrames.clear();
+    }
+
+    @SubscribeEvent
+    public static void onBlockHover(RenderHighlightEvent.Block event) {
+        if(true) return; // TODO: Temporary instant return until we have block models that should be accurate to their BakedModel
+
+        Player player = minecraft.player;
+        if (player == null) {
+            return;
+        }
+
+        BlockHitResult rayTraceResult = event.getTarget();
+        if (rayTraceResult.getType() != HitResult.Type.MISS) {
+            Level world = player.level();
+            BlockPos pos = rayTraceResult.getBlockPos();
+            MultiBufferSource renderer = event.getMultiBufferSource();
+            Camera info = event.getCamera();
+            PoseStack matrix = event.getPoseStack();
+
+            BlockState blockState = world.getBlockState(pos);
+
+
+            if (!blockState.isAir() && world.getWorldBorder().isWithinBounds(pos) /* && TODO: Each custom model that we want to accurately display needs to be checked here */) {
+                ProfilerFiller profiler = world.getProfiler();
+                profiler.push("DIMDELV_CUSTOM_OUTLINE");
+
+                matrix.pushPose();
+                Vec3 viewPosition = info.getPosition();
+                matrix.translate(pos.getX() - viewPosition.x, pos.getY() - viewPosition.y, pos.getZ() - viewPosition.z);
+                renderBlockWireFrame(blockState, renderer.getBuffer(RenderType.lines()), matrix, world.random);
+                matrix.popPose();
+
+                profiler.pop();
+                event.setCanceled(true);
+            }
+        }
+    }
+
+
+
+
+    private static void renderBlockWireFrame(BlockState state, VertexConsumer buffer, PoseStack matrix, RandomSource rand) {
+        List<ModelWireframeExtractor.RenderLine> lines = cachedWireFrames.computeIfAbsent(state, key -> {
+            BakedModel bakedModel = Minecraft.getInstance().getBlockRenderer().getBlockModel(state);
+            return ModelWireframeExtractor.extract(bakedModel, state, rand, ModelData.EMPTY, null);
+        });
+
+        PoseStack.Pose pose = matrix.last();
+        renderVertexWireFrame(lines, buffer, pose.pose(), pose.normal());
+    }
+
+    public static void renderVertexWireFrame(Collection<ModelWireframeExtractor.RenderLine> lines, VertexConsumer buffer, Matrix4f pose, Matrix3f poseNormal) {
+        Vector4f pos = new Vector4f();
+        Vector3f normal = new Vector3f();
+
+        for (ModelWireframeExtractor.RenderLine line : lines) {
+            poseNormal.transform(line.nX(), line.nY(), line.nZ(), normal);
+
+            pose.transform(line.x1(), line.y1(), line.z1(), 1F, pos);
+            buffer.addVertex(pos.x, pos.y, pos.z)
+                    .setColor(0, 0, 0, 102)
+                    .setNormal(normal.x, normal.y, normal.z);
+
+            pose.transform(line.x2(), line.y2(), line.z2(), 1F, pos);
+            buffer.addVertex(pos.x, pos.y, pos.z)
+                    .setColor(0, 0, 0, 102)
+                    .setNormal(normal.x, normal.y, normal.z);
+        }
+    }
+
+
+}

--- a/src/main/java/com/dimensiondelvers/dimensiondelvers/events/client/TextureStitchEvent.java
+++ b/src/main/java/com/dimensiondelvers/dimensiondelvers/events/client/TextureStitchEvent.java
@@ -1,0 +1,16 @@
+package com.dimensiondelvers.dimensiondelvers.events.client;
+
+import com.dimensiondelvers.dimensiondelvers.DimensionDelvers;
+import com.dimensiondelvers.dimensiondelvers.events.RenderEvents;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.client.event.TextureAtlasStitchedEvent;
+
+@EventBusSubscriber(modid = DimensionDelvers.MODID, value = Dist.CLIENT, bus = EventBusSubscriber.Bus.MOD)
+public class TextureStitchEvent {
+    @SubscribeEvent
+    public static void onStitch(TextureAtlasStitchedEvent event) {
+        RenderEvents.resetCached();
+    }
+}

--- a/src/main/java/com/dimensiondelvers/dimensiondelvers/util/VoxelShapeUtils.java
+++ b/src/main/java/com/dimensiondelvers/dimensiondelvers/util/VoxelShapeUtils.java
@@ -1,0 +1,209 @@
+package com.dimensiondelvers.dimensiondelvers.util;
+
+import net.minecraft.core.Direction;
+import net.minecraft.world.level.block.Rotation;
+import net.minecraft.world.phys.AABB;
+import net.minecraft.world.phys.Vec3;
+import net.minecraft.world.phys.shapes.BooleanOp;
+import net.minecraft.world.phys.shapes.Shapes;
+import net.minecraft.world.phys.shapes.VoxelShape;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.function.BiFunction;
+
+public class VoxelShapeUtils {
+    protected static final Direction[] HORIZONTAL_DIRECTIONS = {Direction.NORTH, Direction.SOUTH, Direction.WEST, Direction.EAST};
+    private static final Direction[] DIRECTIONS = Direction.values();
+
+
+    /**
+     * Rotates an {@link AABB} to a given direction
+     *
+     * @param box The {@link AABB} to rotate
+     * @param side The side to rotate it to.
+     *
+     * @return The rotated {@link AABB}
+     */
+    public static AABB rotate(AABB box, Direction side) {
+        return switch (side) {
+            case DOWN -> box;
+            case UP -> new AABB(box.minX, -box.minY, -box.minZ, box.maxX, -box.maxY, -box.maxZ);
+            case NORTH -> new AABB(box.minX, -box.minZ, box.minY, box.maxX, -box.maxZ, box.maxY);
+            case SOUTH -> new AABB(-box.minX, -box.minZ, -box.minY, -box.maxX, -box.maxZ, -box.maxY);
+            case WEST -> new AABB(box.minY, -box.minZ, -box.minX, box.maxY, -box.maxZ, -box.maxX);
+            case EAST -> new AABB(-box.minY, -box.minZ, box.minX, -box.maxY, -box.maxZ, box.maxX);
+        };
+    }
+
+    /**
+     * Rotates an {@link AABB} according to a specific rotation.
+     *
+     * @param box The {@link AABB} to rotate
+     * @param rotation The rotation we are performing.
+     *
+     * @return The rotated {@link AABB}
+     */
+    public static AABB rotate(AABB box, Rotation rotation) {
+        return switch (rotation) {
+            case NONE -> box;
+            case CLOCKWISE_90 -> new AABB(-box.minZ, box.minY, box.minX, -box.maxZ, box.maxY, box.maxX);
+            case CLOCKWISE_180 -> new AABB(-box.minX, box.minY, -box.minZ, -box.maxX, box.maxY, -box.maxZ);
+            case COUNTERCLOCKWISE_90 -> new AABB(box.minZ, box.minY, -box.minX, box.maxZ, box.maxY, -box.maxX);
+        };
+    }
+
+    /**
+     * Rotates a {@link VoxelShape} by applying a transformation function to each {@link AABB} it contains.
+     *
+     * @param shape The {@link VoxelShape} to be rotated.
+     * @param data Additional data to be passed to the transformation function.
+     * @param rotateFunction A function that defines how each {@link AABB} should be transformed.
+     *
+     * @return A new {@link VoxelShape} with all bounding boxes rotated accordingly.
+     */
+    public static <T> VoxelShape rotate(VoxelShape shape, T data, BiFunction<AABB, T, AABB> rotateFunction) {
+        Vec3 fromOrigin = new Vec3(-0.5, -0.5, -0.5);
+
+        List<VoxelShape> rotatedPieces = new ArrayList<>();
+        List<AABB> boundingBoxes = shape.toAabbs(); // Extract individual bounding boxes
+
+        for (AABB boundingBox : boundingBoxes) {
+            // Shift the bounding box to be centered at the origin, apply the rotation, then move it back
+            rotatedPieces.add(Shapes.create(rotateFunction.apply(boundingBox.move(fromOrigin.x, fromOrigin.y, fromOrigin.z), data)
+                    .move(-fromOrigin.x, -fromOrigin.y, -fromOrigin.z)));
+        }
+
+        return combine(rotatedPieces); // Combine rotated bounding boxes into a single VoxelShape
+    }
+
+    /**
+     * Rotates an {@link AABB} to a specific horizontal direction.
+     *
+     * @param box The {@link AABB} to rotate
+     * @param side The direction to rotate it to.
+     *
+     * @return The rotated {@link AABB}
+     */
+    public static AABB rotateHorizontal(AABB box, Direction side) {
+        return switch (side) {
+            case NORTH -> rotate(box, Rotation.NONE);
+            case SOUTH -> rotate(box, Rotation.CLOCKWISE_180);
+            case WEST -> rotate(box, Rotation.COUNTERCLOCKWISE_90);
+            case EAST -> rotate(box, Rotation.CLOCKWISE_90);
+            default -> box;
+        };
+    }
+
+    /**
+     * Rotates a {@link VoxelShape} to a specific side
+     *
+     * @param shape The {@link VoxelShape} to rotate
+     * @param side The side to rotate it to.
+     *
+     * @return The rotated {@link VoxelShape}
+     */
+    public static VoxelShape rotate(VoxelShape shape, Direction side) {
+        return rotate(shape, side, VoxelShapeUtils::rotate);
+    }
+
+
+
+    /**
+     * Rotates a {@link VoxelShape} to a specific side horizontally.
+     *
+     * @param shape The {@link VoxelShape} to rotate
+     * @param side The side to rotate it to.
+     *
+     * @return The rotated {@link VoxelShape}
+     */
+    public static VoxelShape rotateHorizontal(VoxelShape shape, Direction side) {
+        return rotate(shape, side, VoxelShapeUtils::rotateHorizontal);
+    }
+
+    /**
+     * Used to combine a collection of VoxelShapes
+     *
+     * @param shapes The collection of {@link VoxelShape}s to combine
+     *
+     * @return A simplified {@link VoxelShape} including everything that is part of the input shapes.
+     */
+    public static VoxelShape combine(Collection<VoxelShape> shapes) {
+        return batchCombine(Shapes.empty(), BooleanOp.OR, true, shapes);
+    }
+
+    /**
+     * Used for mass combining shapes
+     *
+     * @param shapes The list of {@link VoxelShape}s to include
+     *
+     * @return A simplified {@link VoxelShape} including everything that is part of the input shapes.
+     */
+    public static VoxelShape combine(VoxelShape... shapes) {
+        return batchCombine(Shapes.empty(), BooleanOp.OR, true, shapes);
+    }
+
+    /**
+     * Used for mass combining shapes using a specific {@link BooleanOp} and a given start shape.
+     *
+     * @param base  The {@link VoxelShape} to start with
+     * @param function The {@link BooleanOp} to perform
+     * @param simplify If true, the shape will be optimized via {@link VoxelShape#optimize()},
+     * @param shapes  The collection of {@link VoxelShape}s to include
+     *
+     * @return A combined {@link VoxelShape} based on the input parameters.
+     */
+    public static VoxelShape batchCombine(VoxelShape base, BooleanOp function, boolean simplify, Collection<VoxelShape> shapes) {
+        VoxelShape combinedShape = base;
+        for (VoxelShape shape : shapes) {
+            combinedShape = Shapes.joinUnoptimized(combinedShape, shape, function);
+        }
+        return simplify ? combinedShape.optimize() : combinedShape;
+    }
+
+    /**
+     * Used for mass combining shapes using a specific {@link BooleanOp} and a given start shape.
+     *
+     * @param base  The {@link VoxelShape} to start with
+     * @param function The {@link BooleanOp} to perform
+     * @param simplify If true, the shape will be optimized via {@link VoxelShape#optimize()},
+     * @param shapes The list of {@link VoxelShape}s to include
+     *
+     * @return A {@link VoxelShape} based on the input parameters.
+     */
+    public static VoxelShape batchCombine(VoxelShape base, BooleanOp function, boolean simplify, VoxelShape... shapes) {
+        VoxelShape combinedShape = base;
+        for (VoxelShape shape : shapes) {
+            combinedShape = Shapes.joinUnoptimized(combinedShape, shape, function);
+        }
+        return simplify ? combinedShape.optimize() : combinedShape;
+    }
+
+
+
+    /**
+     * Populates an array with rotated versions of a given {@link VoxelShape}, adjusting for either vertical or horizontal orientation.
+     *
+     * @param shape The base {@link VoxelShape} to rotate.
+     * @param dest The destination array to store the rotated shapes.
+     * @param verticalAxis If true, rotates the shape along all directions, otherwise, rotates it horizontally.
+     * @param invert If true, reverses the rotation direction by using the opposite side.
+     */
+    public static void setShape(VoxelShape shape, VoxelShape[] dest, boolean verticalAxis, boolean invert) {
+        Direction[] dirs = verticalAxis ? DIRECTIONS : HORIZONTAL_DIRECTIONS;
+        for (Direction side : dirs) {
+            dest[verticalAxis ? side.ordinal() : side.ordinal() - 2] = verticalAxis ? VoxelShapeUtils.rotate(shape, invert ? side.getOpposite() : side) : VoxelShapeUtils.rotateHorizontal(shape, side);
+        }
+    }
+
+    /**
+     * Populates an array with horizontally rotated versions of a given {@link VoxelShape}.
+     *
+     * @param shape The base {@link VoxelShape} to rotate.
+     * @param dest The destination array to store the rotated shapes.
+     */
+    public static void setShape(VoxelShape shape, VoxelShape[] dest) {
+        setShape(shape, dest, false, false);
+    }
+}


### PR DESCRIPTION
This PR makes it possible to render the block outlines shown when hovering over a block accurate to their block model
- Subscribes to `RenderHighlightEvent.Block` to replace the outline, currently returns early until we add our custom blockmodels
- Subscribes to `TextureAtlasStitchedEvent ` to refresh the wireframe cache