### PR TITLE
feat: Added inventory snapshot data component

### DIFF
--- a/src/main/java/com/dimensiondelvers/dimensiondelvers/DimensionDelvers.java
+++ b/src/main/java/com/dimensiondelvers/dimensiondelvers/DimensionDelvers.java
@@ -1,17 +1,16 @@
 package com.dimensiondelvers.dimensiondelvers;
 
+import com.dimensiondelvers.dimensiondelvers.commands.InventorySnapshotCommands;
 import com.dimensiondelvers.dimensiondelvers.gui.screen.RuneAnvilScreen;
-import com.dimensiondelvers.dimensiondelvers.init.ModBlocks;
-import com.dimensiondelvers.dimensiondelvers.init.ModCreativeTabs;
-import com.dimensiondelvers.dimensiondelvers.init.ModDataComponentType;
-import com.dimensiondelvers.dimensiondelvers.init.ModItems;
-import com.dimensiondelvers.dimensiondelvers.init.ModMenuTypes;
+import com.dimensiondelvers.dimensiondelvers.init.*;
+import com.dimensiondelvers.dimensiondelvers.server.inventorySnapshot.InventorySnapshotSystem;
 import com.mojang.logging.LogUtils;
 import net.minecraft.client.Minecraft;
 import net.minecraft.core.Registry;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.tags.TagKey;
 import net.minecraft.world.item.CreativeModeTabs;
 import net.minecraft.world.level.block.Blocks;
@@ -27,6 +26,9 @@ import net.neoforged.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.neoforged.neoforge.client.event.RegisterMenuScreensEvent;
 import net.neoforged.neoforge.common.NeoForge;
 import net.neoforged.neoforge.event.BuildCreativeModeTabContentsEvent;
+import net.neoforged.neoforge.event.RegisterCommandsEvent;
+import net.neoforged.neoforge.event.entity.living.LivingDropsEvent;
+import net.neoforged.neoforge.event.entity.player.PlayerEvent;
 import net.neoforged.neoforge.event.server.ServerStartingEvent;
 import org.slf4j.Logger;
 
@@ -44,6 +46,8 @@ public class DimensionDelvers {
         ModItems.ITEMS.register(modEventBus);
         ModMenuTypes.MENUS.register(modEventBus);
         ModCreativeTabs.CREATIVE_MODE_TABS.register(modEventBus);
+        ModAttachments.ATTACHMENT_TYPES.register(modEventBus);
+        ModLootModifiers.GLOBAL_LOOT_MODIFIER_SERIALIZERS.register(modEventBus);
 
         // Register ourselves for server and other game events we are interested in.
         // Note that this is necessary if and only if we want *this* class (DimensionDelvers) to respond directly to events.
@@ -62,9 +66,28 @@ public class DimensionDelvers {
 
         if (Config.logDirtBlock) LOGGER.info("DIRT BLOCK >> {}", BuiltInRegistries.BLOCK.getKey(Blocks.DIRT));
 
-        LOGGER.info(Config.magicNumberIntroduction + Config.magicNumber);
+        LOGGER.info("{} {}", Config.magicNumberIntroduction, Config.magicNumber);
 
         Config.items.forEach((item) -> LOGGER.info("ITEM >> {}", item.toString()));
+    }
+
+    @SubscribeEvent
+    private void registerCommands(RegisterCommandsEvent event) {
+        InventorySnapshotCommands.register(event.getDispatcher(), event.getBuildContext());
+    }
+
+    @SubscribeEvent
+    private void onDropsFromDeath(LivingDropsEvent event) {
+        if (event.getEntity() instanceof ServerPlayer player) {
+            InventorySnapshotSystem.updateSnapshotForDeath(player, event);
+        }
+    }
+
+    @SubscribeEvent
+    private void onPlayerDeath(PlayerEvent.PlayerRespawnEvent event) {
+        if (!event.isEndConquered() && event.getEntity() instanceof ServerPlayer player) {
+            InventorySnapshotSystem.restoreFromSnapshot(player);
+        }
     }
 
     // Add the example block item to the building blocks tab

--- a/src/main/java/com/dimensiondelvers/dimensiondelvers/commands/InventorySnapshotCommands.java
+++ b/src/main/java/com/dimensiondelvers/dimensiondelvers/commands/InventorySnapshotCommands.java
@@ -1,0 +1,37 @@
+package com.dimensiondelvers.dimensiondelvers.commands;
+
+import com.dimensiondelvers.dimensiondelvers.server.inventorySnapshot.InventorySnapshotSystem;
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import net.minecraft.commands.CommandBuildContext;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
+import net.minecraft.network.chat.Component;
+import net.minecraft.server.level.ServerPlayer;
+
+/**
+ * Debug commands for testing the inventory snapshot system
+ */
+public class InventorySnapshotCommands {
+
+    public static void register(CommandDispatcher<CommandSourceStack> dispatcher, CommandBuildContext context) {
+        dispatcher.register(
+                Commands.literal("dimensiondelvers:createInventorySnapshot").executes(
+                    (ctx) -> createInventorySnapshot(ctx.getSource()
+                )
+        ));
+
+    }
+
+    private static int createInventorySnapshot(CommandSourceStack source) {
+        try {
+            ServerPlayer player = source.getPlayerOrException();
+            InventorySnapshotSystem.captureSnapshot(player);
+            source.sendSuccess(() -> Component.literal("Created inventory snapshot"), true);
+            return 1;
+        } catch (CommandSyntaxException e) {
+            return 0;
+        }
+    }
+
+}

--- a/src/main/java/com/dimensiondelvers/dimensiondelvers/init/ModAttachments.java
+++ b/src/main/java/com/dimensiondelvers/dimensiondelvers/init/ModAttachments.java
@@ -1,0 +1,15 @@
+package com.dimensiondelvers.dimensiondelvers.init;
+
+import com.dimensiondelvers.dimensiondelvers.DimensionDelvers;
+import com.dimensiondelvers.dimensiondelvers.server.inventorySnapshot.InventorySnapshot;
+import net.neoforged.neoforge.attachment.AttachmentType;
+import net.neoforged.neoforge.registries.DeferredRegister;
+import net.neoforged.neoforge.registries.NeoForgeRegistries;
+
+import java.util.function.Supplier;
+
+public class ModAttachments {
+    public static final DeferredRegister<AttachmentType<?>> ATTACHMENT_TYPES = DeferredRegister.create(NeoForgeRegistries.ATTACHMENT_TYPES, DimensionDelvers.MODID);
+
+    public static final Supplier<AttachmentType<InventorySnapshot>> INVENTORY_SNAPSHOT = ATTACHMENT_TYPES.register("inventory_snapshot", () -> AttachmentType.builder(InventorySnapshot::new).serialize(InventorySnapshot.CODEC).copyOnDeath().build());
+}

--- a/src/main/java/com/dimensiondelvers/dimensiondelvers/init/ModDataComponentType.java
+++ b/src/main/java/com/dimensiondelvers/dimensiondelvers/init/ModDataComponentType.java
@@ -1,10 +1,10 @@
 package com.dimensiondelvers.dimensiondelvers.init;
 
 import com.dimensiondelvers.dimensiondelvers.DimensionDelvers;
-import com.dimensiondelvers.dimensiondelvers.item.runegem.Runegem;
 import com.dimensiondelvers.dimensiondelvers.item.runegem.RunegemData;
 import com.dimensiondelvers.dimensiondelvers.item.socket.GearSockets;
 import com.mojang.serialization.Codec;
+import net.minecraft.core.UUIDUtil;
 import net.minecraft.core.component.DataComponentType;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.network.RegistryFriendlyByteBuf;
@@ -12,13 +12,17 @@ import net.minecraft.network.codec.StreamCodec;
 import net.neoforged.neoforge.registries.DeferredHolder;
 import net.neoforged.neoforge.registries.DeferredRegister;
 
+import javax.annotation.Nullable;
+import java.util.UUID;
+
 public class ModDataComponentType {
     public static final DeferredRegister.DataComponents DATA_COMPONENTS = DeferredRegister.createDataComponents(Registries.DATA_COMPONENT_TYPE, DimensionDelvers.MODID);
 
     public static final DeferredHolder<DataComponentType<?>, DataComponentType<GearSockets>> GEAR_SOCKETS  = register("gear_sockets", GearSockets.CODEC, null);//, GearSockets.STREAM_CODEC);
     public static final DeferredHolder<DataComponentType<?>, DataComponentType<RunegemData>> RUNEGEM_DATA  = register("runegem_data", RunegemData.CODEC, null);
+    public static final DeferredHolder<DataComponentType<?>, DataComponentType<UUID>> INVENTORY_SNAPSHOT_ID = register("inventory_snapshot_id", UUIDUtil.CODEC, null);
 
-    private static <T> DeferredHolder<DataComponentType<?>, DataComponentType<T>> register(String name, final Codec<T> codec, final StreamCodec<? super RegistryFriendlyByteBuf, T> streamCodec) {
+    private static <T> DeferredHolder<DataComponentType<?>, DataComponentType<T>> register(String name, final Codec<T> codec, @Nullable final StreamCodec<? super RegistryFriendlyByteBuf, T> streamCodec) {
         if (streamCodec == null) {
             return DATA_COMPONENTS.register(name, () -> DataComponentType.<T>builder().persistent(codec).build());
         } else {

--- a/src/main/java/com/dimensiondelvers/dimensiondelvers/init/ModLootModifiers.java
+++ b/src/main/java/com/dimensiondelvers/dimensiondelvers/init/ModLootModifiers.java
@@ -1,0 +1,18 @@
+package com.dimensiondelvers.dimensiondelvers.init;
+
+import com.dimensiondelvers.dimensiondelvers.DimensionDelvers;
+import com.dimensiondelvers.dimensiondelvers.server.inventorySnapshot.RetainInventorySnapshotLootModifier;
+import com.mojang.serialization.MapCodec;
+import net.neoforged.neoforge.common.loot.IGlobalLootModifier;
+import net.neoforged.neoforge.registries.DeferredRegister;
+import net.neoforged.neoforge.registries.NeoForgeRegistries;
+
+import java.util.function.Supplier;
+
+public class ModLootModifiers {
+    public static final DeferredRegister<MapCodec<? extends IGlobalLootModifier>> GLOBAL_LOOT_MODIFIER_SERIALIZERS =
+            DeferredRegister.create(NeoForgeRegistries.Keys.GLOBAL_LOOT_MODIFIER_SERIALIZERS, DimensionDelvers.MODID);
+
+    public static final Supplier<MapCodec<RetainInventorySnapshotLootModifier>> RETAIN_INVENTORY_SNAPSHOT =
+            GLOBAL_LOOT_MODIFIER_SERIALIZERS.register("retain_inventory_snapshot", () -> RetainInventorySnapshotLootModifier.CODEC);
+}

--- a/src/main/java/com/dimensiondelvers/dimensiondelvers/server/inventorySnapshot/InventorySnapshot.java
+++ b/src/main/java/com/dimensiondelvers/dimensiondelvers/server/inventorySnapshot/InventorySnapshot.java
@@ -1,0 +1,110 @@
+package com.dimensiondelvers.dimensiondelvers.server.inventorySnapshot;
+
+import com.dimensiondelvers.dimensiondelvers.init.ModDataComponentType;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import net.minecraft.core.UUIDUtil;
+import net.minecraft.core.component.DataComponentPatch;
+import net.minecraft.core.component.DataComponents;
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.codec.ByteBufCodecs;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.component.ItemContainerContents;
+
+import java.util.*;
+
+/**
+ * InventorySnapshot is used to record the contents of a player's inventory at a point in time.
+ */
+public class InventorySnapshot {
+    private final Set<UUID> itemIds;
+    private final List<ItemStack> items;
+
+    public static final Codec<InventorySnapshot> CODEC = RecordCodecBuilder.create(
+            instance -> instance.group(
+                        UUIDUtil.CODEC.listOf().fieldOf("itemIds").forGetter(x -> new ArrayList<>(x.itemIds)),
+                        ItemStack.CODEC.listOf().fieldOf("items").forGetter(x -> x.items)
+                    ).apply(instance, InventorySnapshot::new)
+    );
+    public static final StreamCodec<RegistryFriendlyByteBuf, InventorySnapshot> STREAM_CODEC = StreamCodec.composite(
+            UUIDUtil.STREAM_CODEC.apply(ByteBufCodecs.list()),
+            x -> new ArrayList<>(x.itemIds),
+            ItemStack.STREAM_CODEC.apply(ByteBufCodecs.list()),
+            InventorySnapshot::items,
+            InventorySnapshot::new
+    );
+
+    /**
+     * Generates an InventorySnapshot for a player's inventory
+     * @param player
+     * @return A new InventorySnapshot
+     */
+    public static InventorySnapshot capture(ServerPlayer player) {
+        Set<UUID> itemIds = new LinkedHashSet<>();
+        List<ItemStack> itemStacks = new ArrayList<>();
+
+        for (ItemStack item : player.getInventory().items) {
+            captureItem(item, itemIds, itemStacks);
+        }
+        for (ItemStack item : player.getInventory().armor) {
+            captureItem(item, itemIds, itemStacks);
+        }
+        captureItem(player.getOffhandItem(), itemIds, itemStacks);
+        return new InventorySnapshot(itemIds, itemStacks);
+    }
+
+    private static void captureItem(ItemStack item, Set<UUID> itemIds, List<ItemStack> itemStacks) {
+        if (item.isEmpty()) {
+            return;
+        }
+        if (item.isStackable()) {
+            itemStacks.add(item.copy());
+        } else {
+            UUID id = UUID.randomUUID();
+            item.applyComponents(DataComponentPatch.builder().set(ModDataComponentType.INVENTORY_SNAPSHOT_ID.get(), id).build());
+            itemIds.add(id);
+
+            if (item.has(DataComponents.CONTAINER)) {
+                ItemContainerContents contents = item.get(DataComponents.CONTAINER);
+                for (ItemStack nonEmptyItem : contents.nonEmptyItems()) {
+                    captureItem(nonEmptyItem, itemIds, itemStacks);
+                }
+            }
+        }
+    }
+
+    public InventorySnapshot() {
+        this(Collections.emptyList(), Collections.emptyList());
+    }
+
+    public InventorySnapshot(Collection<UUID> itemIds, Collection<ItemStack> items) {
+        this.itemIds = new LinkedHashSet<>(itemIds);
+        this.items = new ArrayList<>(items);
+    }
+
+    public Set<UUID> itemIds() {
+        return Collections.unmodifiableSet(itemIds);
+    }
+
+    public List<ItemStack> items() {
+        return Collections.unmodifiableList(items);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) {
+            return true;
+        }
+        if (obj instanceof InventorySnapshot other) {
+            return Objects.equals(itemIds, other.itemIds) && Objects.equals(items, other.items);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(itemIds, items);
+    }
+}

--- a/src/main/java/com/dimensiondelvers/dimensiondelvers/server/inventorySnapshot/InventorySnapshotSystem.java
+++ b/src/main/java/com/dimensiondelvers/dimensiondelvers/server/inventorySnapshot/InventorySnapshotSystem.java
@@ -1,0 +1,210 @@
+package com.dimensiondelvers.dimensiondelvers.server.inventorySnapshot;
+
+import com.dimensiondelvers.dimensiondelvers.init.ModAttachments;
+import com.dimensiondelvers.dimensiondelvers.init.ModDataComponentType;
+import net.minecraft.core.component.DataComponentPatch;
+import net.minecraft.core.component.DataComponents;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.item.ItemEntity;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.component.ItemContainerContents;
+import net.neoforged.neoforge.event.entity.living.LivingDropsEvent;
+
+import java.util.*;
+
+/**
+ * Implementation for capture, update and restoration of Inventory Snapshots
+ * <p></p>
+ * The envisioned behavior is:
+ * <ul>
+ *     <li>When a snapshot is initially captured, all items in the players inventory and sub-inventories are enumerated</li>
+ *     <li>When a player dies, the player's inventory is compared to the snapshot. The snapshot is reduced to the remaining items and any excess is dropped (mechanism TBD)</li>
+ *     <li>When a player respawns the items in the snapshot are returned and the snapshot is removed</li>
+ * </ul>
+ * <p></p>
+ * The implementation is to tag any non-stackable items, and directly record any stackable, with the assumption that stackable items will
+ * not vary in a non-comparable manner.
+ */
+public class InventorySnapshotSystem {
+
+    private static final DataComponentPatch REMOVE_SNAPSHOT_ID_PATCH = DataComponentPatch.builder().remove(ModDataComponentType.INVENTORY_SNAPSHOT_ID.get()).build();
+
+    /**
+     * Generates a snapshot for the given player
+     *
+     * @param player
+     */
+    public static void captureSnapshot(ServerPlayer player) {
+        clearItemIds(player);
+        player.setData(ModAttachments.INVENTORY_SNAPSHOT, InventorySnapshot.capture(player));
+    }
+
+    /**
+     * Clears any snapshot on the player
+     *
+     * @param player
+     */
+    public static void clearSnapshot(ServerPlayer player) {
+        clearItemIds(player);
+        player.setData(ModAttachments.INVENTORY_SNAPSHOT, new InventorySnapshot());
+    }
+
+    /**
+     * Updates the snapshot for the player's death. This will reduce the captured items to what the player
+     * still had on them at time of death.
+     *
+     * @param player
+     * @param event
+     */
+    public static void updateSnapshotForDeath(ServerPlayer player, LivingDropsEvent event) {
+        InventorySnapshot snapshot = player.getData(ModAttachments.INVENTORY_SNAPSHOT);
+        if (snapshot.itemIds().isEmpty() && snapshot.items().isEmpty()) {
+            return;
+        }
+
+        DeathDropCalculator refiner = new DeathDropCalculator(player, snapshot, event.getDrops());
+
+        event.getDrops().clear();
+        event.getDrops().addAll(refiner.dropItems);
+
+        player.setData(ModAttachments.INVENTORY_SNAPSHOT, new InventorySnapshot(Collections.emptyList(), refiner.retainItems));
+    }
+
+    /**
+     * Populate the player's inventory with all items from their snapshot, drop any that don't fit
+     *
+     * @param player
+     */
+    public static void restoreFromSnapshot(ServerPlayer player) {
+        InventorySnapshot snapshot = player.getData(ModAttachments.INVENTORY_SNAPSHOT);
+
+        for (ItemStack item : snapshot.items()) {
+            if (!player.getInventory().add(item)) {
+                item.applyComponents(REMOVE_SNAPSHOT_ID_PATCH);
+                player.level().addFreshEntity(new ItemEntity(player.level(), player.position().x, player.position().y, player.position().z, item));
+            }
+        }
+        player.setData(ModAttachments.INVENTORY_SNAPSHOT, new InventorySnapshot());
+        clearItemIds(player);
+    }
+
+    private static final class DeathDropCalculator {
+        private final List<ItemStack> retainItems = new ArrayList<>();
+        private final List<ItemEntity> dropItems = new ArrayList<>();
+
+        private ServerPlayer player;
+        private List<ItemStack> snapshotItems;
+        private Set<UUID> snapshotItemIds;
+
+        public DeathDropCalculator(ServerPlayer player, InventorySnapshot snapshot, Collection<ItemEntity> heldItems) {
+            this.player = player;
+            this.snapshotItems = new ArrayList<>(snapshot.items());
+            this.snapshotItemIds = snapshot.itemIds();
+            processInventoryItems(heldItems);
+        }
+
+        private void processInventoryItems(Collection<ItemEntity> drops) {
+            for (ItemEntity itemEntity : drops) {
+                ItemStack item = itemEntity.getItem();
+
+                if (item.getComponents().has(ModDataComponentType.INVENTORY_SNAPSHOT_ID.get()) && snapshotItemIds.contains(item.getComponents().get(ModDataComponentType.INVENTORY_SNAPSHOT_ID.get()))) {
+                    if (item.has(DataComponents.CONTAINER)) {
+                        processContainerContents(item, true);
+                    }
+                    retainItems.add(item);
+                } else if (item.isStackable()) {
+                    int dropCount = calculateDropCount(item);
+
+                    if (dropCount < item.getCount()) {
+                        retainItems.add(item.split(item.getCount() - dropCount));
+                    }
+                    if (!item.isEmpty()) {
+                        dropItems.add(itemEntity);
+                    }
+                } else {
+                    if (item.has(DataComponents.CONTAINER)) {
+                        processContainerContents(item, false);
+                    }
+                    itemEntity.getItem().applyComponents(REMOVE_SNAPSHOT_ID_PATCH);
+                    dropItems.add(itemEntity);
+                }
+            }
+        }
+
+        // If we're retaining the container
+        // - Any item that should be retained keep in container
+        // - Any item that we don't want, copy and clear and drop the copy
+        // If we're not retaining the container
+        // - Any item that should be retained copy and clear and put the copy in retain
+        // - Any item that we don't want, keep in container
+        private void processContainerContents(ItemStack containerItem, boolean retainingContainer) {
+            ItemContainerContents itemContainerContents = containerItem.get(DataComponents.CONTAINER);
+            for (ItemStack item : itemContainerContents.nonEmptyItems()) {
+                if (item.getComponents().has(ModDataComponentType.INVENTORY_SNAPSHOT_ID.get()) && snapshotItemIds.contains(item.getComponents().get(ModDataComponentType.INVENTORY_SNAPSHOT_ID.get()))) {
+                    if (item.has(DataComponents.CONTAINER)) {
+                        processContainerContents(item, true);
+                    }
+
+                    if (!retainingContainer) {
+                        retainItems.add(item.copyAndClear());
+                    }
+                } else if (item.isStackable()) {
+                    int dropCount = calculateDropCount(item);
+
+                    if (retainingContainer && dropCount > 0) {
+                        dropItems.add(createItemEntity(item.split(dropCount)));
+                    } else if (!retainingContainer && dropCount < item.getCount()) {
+                        retainItems.add(item.split(item.getCount() - dropCount));
+                    }
+                } else if (retainingContainer) {
+                    item.applyComponents(REMOVE_SNAPSHOT_ID_PATCH);
+                    dropItems.add(createItemEntity(item.copyAndClear()));
+                }
+            }
+        }
+
+        private int calculateDropCount(ItemStack item) {
+            int dropCount = item.getCount();
+
+            // Walk through the list of snapshotted items, reducing stack counts of matching stacks until all items are accounted for
+            int index = 0;
+            while (dropCount > 0 && index < snapshotItems.size()) {
+                ItemStack snapshotItem = snapshotItems.get(index);
+                if (ItemStack.isSameItemSameComponents(item, snapshotItem)) {
+                    if (dropCount <= snapshotItem.getCount()) {
+                        snapshotItem.shrink(dropCount);
+                        dropCount = 0;
+                    } else {
+                        snapshotItems.remove(index);
+                        dropCount -= snapshotItem.getCount();
+                    }
+                } else {
+                    index++;
+                }
+            }
+            return dropCount;
+        }
+
+        private ItemEntity createItemEntity(ItemStack stack) {
+            return new ItemEntity(player.level(), player.position().x, player.position().y, player.position().z, stack);
+        }
+    }
+
+    /**
+     * Clears all snapshot item id components from items in the player's inventory
+     *
+     * @param player
+     */
+    private static void clearItemIds(ServerPlayer player) {
+        DataComponentPatch removeIdPatch = DataComponentPatch.builder().remove(ModDataComponentType.INVENTORY_SNAPSHOT_ID.get()).build();
+        for (ItemStack item : player.getInventory().items) {
+            item.applyComponents(removeIdPatch);
+        }
+        for (ItemStack item : player.getInventory().armor) {
+            item.applyComponents(removeIdPatch);
+        }
+        for (ItemStack item : player.getInventory().offhand) {
+            item.applyComponents(removeIdPatch);
+        }
+    }
+}

--- a/src/main/java/com/dimensiondelvers/dimensiondelvers/server/inventorySnapshot/RetainInventorySnapshotLootModifier.java
+++ b/src/main/java/com/dimensiondelvers/dimensiondelvers/server/inventorySnapshot/RetainInventorySnapshotLootModifier.java
@@ -1,0 +1,45 @@
+package com.dimensiondelvers.dimensiondelvers.server.inventorySnapshot;
+
+import com.dimensiondelvers.dimensiondelvers.init.ModDataComponentType;
+import com.mojang.serialization.MapCodec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import it.unimi.dsi.fastutil.objects.ObjectArrayList;
+import net.minecraft.core.component.DataComponentPatch;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.storage.loot.LootContext;
+import net.minecraft.world.level.storage.loot.parameters.LootContextParams;
+import net.minecraft.world.level.storage.loot.predicates.LootItemCondition;
+import net.neoforged.neoforge.common.loot.IGlobalLootModifier;
+import net.neoforged.neoforge.common.loot.LootModifier;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.UUID;
+
+/**
+ * This Loot Modifier ensures that the inventory snapshot id is retained when an item is placed as a block and then destroyed.
+ */
+public class RetainInventorySnapshotLootModifier extends LootModifier {
+
+    public static final MapCodec<RetainInventorySnapshotLootModifier> CODEC = RecordCodecBuilder.mapCodec(inst ->
+            LootModifier.codecStart(inst).apply(inst, RetainInventorySnapshotLootModifier::new));
+
+    protected RetainInventorySnapshotLootModifier(LootItemCondition[] conditions) {
+        super(conditions);
+    }
+
+    @Override
+    protected @NotNull ObjectArrayList<ItemStack> doApply(ObjectArrayList<ItemStack> generatedLoot, LootContext context) {
+        BlockEntity blockEntity = context.getParamOrNull(LootContextParams.BLOCK_ENTITY);
+        if (generatedLoot.size() == 1 && blockEntity != null && blockEntity.components().has(ModDataComponentType.INVENTORY_SNAPSHOT_ID.get())) {
+            UUID blockId = blockEntity.components().get(ModDataComponentType.INVENTORY_SNAPSHOT_ID.get());
+            generatedLoot.getFirst().applyComponents(DataComponentPatch.builder().set(ModDataComponentType.INVENTORY_SNAPSHOT_ID.get(), blockId).build());
+        }
+        return generatedLoot;
+    }
+
+    @Override
+    public @NotNull MapCodec<? extends IGlobalLootModifier> codec() {
+        return CODEC;
+    }
+}

--- a/src/main/resources/data/dimensiondelvers/loot_modifiers/retain_inventory_snapshot.json
+++ b/src/main/resources/data/dimensiondelvers/loot_modifiers/retain_inventory_snapshot.json
@@ -1,0 +1,5 @@
+{
+  "type": "dimensiondelvers:retain_inventory_snapshot",
+  "conditions" : [
+  ]
+}

--- a/src/main/resources/data/neoforge/loot_modifiers/global_loot_modifiers.json
+++ b/src/main/resources/data/neoforge/loot_modifiers/global_loot_modifiers.json
@@ -1,0 +1,6 @@
+{
+  "replace" : false,
+  "entries" : [
+    "dimensiondelvers:retain_inventory_snapshot"
+  ]
+}


### PR DESCRIPTION
The current system captures items the player is carrying as a snapshot, and then on death will find the intersection between the snapshot and their held items and restore them to the player.

The command `dimensiondelvers:createInventorySnapshot` will create the snapshot, and the snapshot will applied on subsequent death and deleted.