### PR TITLE
Prevent durability damage in its entirety

### DIFF
--- a/src/main/java/com/wanderersoftherift/wotr/mixin/MixinItemStack.java
+++ b/src/main/java/com/wanderersoftherift/wotr/mixin/MixinItemStack.java
@@ -1,4 +1,4 @@
-package com.dimensiondelvers.dimensiondelvers.mixin;
+package com.wanderersoftherift.wotr.mixin;
 
 import net.minecraft.world.item.ItemStack;
 import org.spongepowered.asm.mixin.Mixin;

--- a/src/main/java/com/wanderersoftherift/wotr/mixin/MixinItemStack.java
+++ b/src/main/java/com/wanderersoftherift/wotr/mixin/MixinItemStack.java
@@ -1,0 +1,16 @@
+package com.dimensiondelvers.dimensiondelvers.mixin;
+
+import net.minecraft.world.item.ItemStack;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(ItemStack.class)
+public abstract class MixinItemStack {
+
+    @Inject(method = "isDamageableItem", at = @At("HEAD"), cancellable = true)
+    private void preventDurability(CallbackInfoReturnable<Boolean> cir) {
+        cir.setReturnValue(false); // We may want certain items to be excluded, which can be done here, currently all items are targeted
+    }
+}

--- a/src/main/java/com/wanderersoftherift/wotr/mixin/MixinSetItemDamageFunction.java
+++ b/src/main/java/com/wanderersoftherift/wotr/mixin/MixinSetItemDamageFunction.java
@@ -1,0 +1,21 @@
+package com.dimensiondelvers.dimensiondelvers.mixin;
+
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.storage.loot.LootContext;
+import net.minecraft.world.level.storage.loot.functions.SetItemDamageFunction;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(SetItemDamageFunction.class)
+public class MixinSetItemDamageFunction {
+
+    // Prevents the log from being spammed whenever this runs
+    // isDamageableItem currently always returns false with the no-durability implementation
+    // so this method running is unneccessary currently
+    @Inject(method = "run", at = @At("HEAD"), cancellable = true)
+    private void preventConsoleSpam(ItemStack stack, LootContext context, CallbackInfoReturnable<ItemStack> cir) {
+        cir.setReturnValue(stack);
+    }
+}

--- a/src/main/java/com/wanderersoftherift/wotr/mixin/MixinSetItemDamageFunction.java
+++ b/src/main/java/com/wanderersoftherift/wotr/mixin/MixinSetItemDamageFunction.java
@@ -1,4 +1,4 @@
-package com.dimensiondelvers.dimensiondelvers.mixin;
+package com.wanderersoftherift.wotr.mixin;
 
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.storage.loot.LootContext;

--- a/src/main/resources/wotr.mixins.json
+++ b/src/main/resources/wotr.mixins.json
@@ -5,7 +5,9 @@
   "compatibilityLevel": "JAVA_8",
   "refmap": "wotr.refmap.json",
   "mixins": [
-    "MixinEnchantingTableBlock"
+    "MixinEnchantingTableBlock",
+    "MixinItemStack",
+    "MixinSetItemDamageFunction"
   ],
   "client": [
     "MixinAccessibilityOptionsScreen",


### PR DESCRIPTION
This PR removes durability damage from the game in its entirety, by always returning false when the `ItemStack#isDamageableItem` method is called.
