### PR TITLE
SpawnPiece withPOIs command

### DIFF
--- a/src/main/java/com/wanderersoftherift/wotr/commands/SpawnPieceCommand.java
+++ b/src/main/java/com/wanderersoftherift/wotr/commands/SpawnPieceCommand.java
@@ -1,12 +1,19 @@
 package com.wanderersoftherift.wotr.commands;
 
 import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.arguments.BoolArgumentType;
 import com.mojang.brigadier.arguments.IntegerArgumentType;
 import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.exceptions.DynamicCommandExceptionType;
 import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
 import com.mojang.brigadier.tree.LiteralCommandNode;
+import com.mojang.datafixers.util.Pair;
+import com.wanderersoftherift.wotr.init.ModRiftThemes;
+import com.wanderersoftherift.wotr.world.level.levelgen.processor.ThemeProcessor;
+import com.wanderersoftherift.wotr.world.level.levelgen.theme.LevelRiftThemeData;
+import com.wanderersoftherift.wotr.world.level.levelgen.theme.RiftTheme;
+import com.wanderersoftherift.wotr.world.level.levelgen.theme.ThemePieceType;
 import net.minecraft.ResourceLocationException;
 import net.minecraft.commands.CommandBuildContext;
 import net.minecraft.commands.CommandSourceStack;
@@ -16,9 +23,15 @@ import net.minecraft.commands.arguments.ResourceKeyArgument;
 import net.minecraft.commands.arguments.ResourceLocationArgument;
 import net.minecraft.commands.arguments.TemplateMirrorArgument;
 import net.minecraft.commands.arguments.TemplateRotationArgument;
-import net.minecraft.commands.arguments.coordinates.*;
+import net.minecraft.commands.arguments.coordinates.BlockPosArgument;
+import net.minecraft.commands.arguments.coordinates.Coordinates;
+import net.minecraft.commands.arguments.coordinates.Vec3Argument;
+import net.minecraft.commands.arguments.coordinates.WorldCoordinate;
+import net.minecraft.commands.arguments.coordinates.WorldCoordinates;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
+import net.minecraft.core.Registry;
+import net.minecraft.core.Vec3i;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
@@ -34,9 +47,26 @@ import net.minecraft.world.level.block.entity.StructureBlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.StructureMode;
 import net.minecraft.world.level.chunk.ChunkAccess;
-import net.minecraft.world.level.levelgen.structure.templatesystem.*;
+import net.minecraft.world.level.levelgen.LegacyRandomSource;
+import net.minecraft.world.level.levelgen.WorldgenRandom;
+import net.minecraft.world.level.levelgen.structure.BoundingBox;
+import net.minecraft.world.level.levelgen.structure.PoolElementStructurePiece;
+import net.minecraft.world.level.levelgen.structure.Structure;
+import net.minecraft.world.level.levelgen.structure.StructurePiece;
+import net.minecraft.world.level.levelgen.structure.pools.DimensionPadding;
+import net.minecraft.world.level.levelgen.structure.pools.JigsawPlacement;
+import net.minecraft.world.level.levelgen.structure.pools.StructurePoolElement;
+import net.minecraft.world.level.levelgen.structure.pools.StructureTemplatePool;
+import net.minecraft.world.level.levelgen.structure.pools.alias.PoolAliasLookup;
+import net.minecraft.world.level.levelgen.structure.templatesystem.LiquidSettings;
+import net.minecraft.world.level.levelgen.structure.templatesystem.StructurePlaceSettings;
+import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessor;
+import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessorList;
+import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
+import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplateManager;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
@@ -44,6 +74,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 public class SpawnPieceCommand {
+    private static final ResourceLocation EMPTY_TEMPLATE = ResourceLocation.fromNamespaceAndPath("minecraft", "empty");
     private static final DynamicCommandExceptionType ERROR_TEMPLATE_INVALID = new DynamicCommandExceptionType(
         templateId -> Component.translatableEscape("commands.place.template.invalid", templateId)
     );
@@ -60,6 +91,8 @@ public class SpawnPieceCommand {
         String commandString = "spawnpiece";
         String rlArg = "resourcelocationpath";
         String locationArg = "location";
+        String themeArg = "theme";
+        String terminateArg = "includeTerminators";
         String processorArg = "processor";
         String rotationArg = "rotation";
         String mirrorArg = "mirror";
@@ -84,6 +117,55 @@ public class SpawnPieceCommand {
                                     cs);
                             return 0;
                         })
+                        .then(Commands.literal("withPOIs")
+                                .then(Commands.argument(themeArg, ResourceKeyArgument.key(ModRiftThemes.RIFT_THEME_KEY))
+                                        .executes(cs -> {
+                                            WorldCoordinates worldCoordinates = new WorldCoordinates(
+                                                    new WorldCoordinate(false, cs.getSource().getPosition().x()),
+                                                    new WorldCoordinate(false, cs.getSource().getPosition().y()),
+                                                    new WorldCoordinate(false, cs.getSource().getPosition().z())
+                                            );
+                                            spawnPieceFully(cs.getArgument(rlArg, ResourceLocation.class),
+                                                    worldCoordinates,
+                                                    ResourceKeyArgument.resolveKey(cs, themeArg, ModRiftThemes.RIFT_THEME_KEY, ERROR_INVALID_PROCESSOR),
+                                                    true,
+                                                    cs.getSource().getLevel().getRandom().nextInt(),
+                                                    cs);
+                                            return 0;
+                                        })
+                                        .then(Commands.argument(locationArg, Vec3Argument.vec3())
+                                                .executes(cs -> {
+                                                    spawnPieceFully(cs.getArgument(rlArg, ResourceLocation.class),
+                                                            Vec3Argument.getCoordinates(cs, locationArg),
+                                                            ResourceKeyArgument.resolveKey(cs, themeArg, ModRiftThemes.RIFT_THEME_KEY, ERROR_INVALID_PROCESSOR),
+                                                            true,
+                                                            cs.getSource().getLevel().getRandom().nextInt(),
+                                                            cs);
+                                                    return 0;
+                                                }).then(Commands.argument(terminateArg, BoolArgumentType.bool())
+                                                        .executes(
+                                                                cs -> {
+                                                                    spawnPieceFully(cs.getArgument(rlArg, ResourceLocation.class),
+                                                                            Vec3Argument.getCoordinates(cs, locationArg),
+                                                                            ResourceKeyArgument.resolveKey(cs, themeArg, ModRiftThemes.RIFT_THEME_KEY, ERROR_INVALID_PROCESSOR),
+                                                                            BoolArgumentType.getBool(cs, terminateArg),
+                                                                            cs.getSource().getLevel().getRandom().nextInt(),
+                                                                            cs);
+                                                                    return 0;
+                                                                }).then(Commands.argument(seedArg, IntegerArgumentType.integer())
+                                                                .executes(cs -> {
+                                                                    spawnPieceFully(cs.getArgument(rlArg, ResourceLocation.class),
+                                                                            Vec3Argument.getCoordinates(cs, locationArg),
+                                                                            ResourceKeyArgument.resolveKey(cs, themeArg, ModRiftThemes.RIFT_THEME_KEY, ERROR_INVALID_PROCESSOR),
+                                                                            BoolArgumentType.getBool(cs, terminateArg),
+                                                                            IntegerArgumentType.getInteger(cs, seedArg),
+                                                                            cs);
+                                                                 return 0;
+                                                                }))
+                                                )
+                                        )
+                                )
+                        )
                         .then(Commands.argument(locationArg, Vec3Argument.vec3())
                                 .executes(cs -> {
                                     spawnPiece(cs.getArgument(rlArg, ResourceLocation.class),
@@ -173,7 +255,17 @@ public class SpawnPieceCommand {
         generateStructurePiece(level, pos, player, path, processors, rotation, mirror, seed, cs);
     }
 
-    private static void generateStructurePiece(ServerLevel world, BlockPos pos, Player player, ResourceLocation nbt, StructureProcessorList processorList, Rotation rotation, Mirror mirror, int seed, CommandContext<CommandSourceStack> cs) throws CommandSyntaxException {
+    public static void spawnPieceFully(ResourceLocation path, Coordinates coordinates, Holder.Reference<RiftTheme> theme, boolean includeTerminators, int seed, CommandContext<CommandSourceStack> cs) throws CommandSyntaxException {
+        if (cs.getSource().getEntity() instanceof Player player) {
+            player.displayClientMessage(Component.translatable("command.spawn_piece.generating", path.toString()), true);
+        }
+        BlockPos pos = coordinates.getBlockPos(cs.getSource());
+        placeStructure(path, pos.mutable(), theme, includeTerminators, seed, cs);
+    }
+
+    private static void generateStructurePiece(ServerLevel world, BlockPos pos, Player player, ResourceLocation
+                                                       nbt, StructureProcessorList processorList, Rotation rotation, Mirror mirror,
+                                               int seed, CommandContext<CommandSourceStack> cs) throws CommandSyntaxException {
         if (player != null) {
             player.displayClientMessage(Component.translatable("command.spawn_piece.generating", nbt.toString()), true);
         }
@@ -219,7 +311,82 @@ public class SpawnPieceCommand {
         });
     }
 
-    public static int placeTemplate(ResourceLocation template, BlockPos pos, List<StructureProcessor> processorList, Rotation rotation, Mirror mirror, int seed, CommandContext<CommandSourceStack> cs) throws CommandSyntaxException {
+    public static int placeStructure(ResourceLocation template, BlockPos pos, Holder<RiftTheme> theme,
+                                     boolean includeTerminators, int seed, CommandContext<CommandSourceStack> cs) throws CommandSyntaxException {
+        ServerLevel serverlevel = cs.getSource().getLevel();
+        StructureTemplateManager structuretemplatemanager = serverlevel.getStructureManager();
+
+        LevelRiftThemeData riftThemeData = LevelRiftThemeData.getFromLevel(serverlevel);
+        Holder<RiftTheme> originalTheme = riftThemeData.getTheme();
+        riftThemeData.setTheme(theme);
+        try {
+            Optional<StructureTemplate> optionalTemplate = structuretemplatemanager.get(template);
+            if (optionalTemplate.isEmpty()) {
+                throw ERROR_TEMPLATE_INVALID.create(template);
+            }
+            StructureTemplate structuretemplate = optionalTemplate.get();
+            checkLoaded(serverlevel, new ChunkPos(pos), new ChunkPos(pos.offset(structuretemplate.getSize())));
+
+            Holder<StructureProcessorList> structureProcessorList = Holder.direct(new StructureProcessorList(Collections.singletonList(new ThemeProcessor(ThemePieceType.ROOM))));
+            Registry<StructureTemplatePool> poolRegistry = serverlevel.registryAccess().lookupOrThrow(Registries.TEMPLATE_POOL);
+            StructureTemplatePool pool = new StructureTemplatePool(poolRegistry.get(EMPTY_TEMPLATE).get(), Collections.singletonList(new Pair<>(StructurePoolElement.single(template.toString(), structureProcessorList).apply(StructureTemplatePool.Projection.RIGID), 1)));
+            Structure.GenerationContext context = new Structure.GenerationContext(serverlevel.registryAccess(), serverlevel.getChunkSource().getGenerator(), serverlevel.getChunkSource().getGenerator().getBiomeSource(), serverlevel.getChunkSource().randomState(), serverlevel.getStructureManager(), seed, new ChunkPos(pos), serverlevel, (biomeHolder -> true));
+
+            Optional<Structure.GenerationStub> pieceGenerator = JigsawPlacement.addPieces(
+                    context,
+                    Holder.direct(pool),
+                    Optional.empty(),
+                    1,
+                    pos,
+                    false,
+                    Optional.empty(),
+                    80,
+                    PoolAliasLookup.EMPTY,
+                    DimensionPadding.ZERO,
+                    LiquidSettings.IGNORE_WATERLOGGING);
+
+            List<StructurePiece> structurePieceList = pieceGenerator.get().getPiecesBuilder().build().pieces();
+
+            if (structurePieceList.isEmpty()) {
+                throw ERROR_TEMPLATE_INVALID.create(template);
+            }
+
+            // Correct location for rotation
+            BoundingBox boundingBox = structurePieceList.getFirst().getBoundingBox();
+            Vec3i offset = new Vec3i(boundingBox.minX() < pos.getX()? boundingBox.getXSpan() - 1 : 0, 0, boundingBox.minZ() < pos.getZ() ? boundingBox.getZSpan() - 1 : 0);
+
+            structurePieceList.forEach(piece -> {
+                if (!includeTerminators && piece instanceof PoolElementStructurePiece poolPiece && poolPiece.getElement().toString().contains("terminator")) {
+                    return;
+                }
+                piece.move(offset.getX(), 0, offset.getZ());
+                piece.postProcess(
+                        serverlevel,
+                        serverlevel.structureManager(),
+                        serverlevel.getChunkSource().getGenerator(),
+                        new WorldgenRandom(new LegacyRandomSource(seed)),
+                        BoundingBox.infinite(),
+                        new ChunkPos(pos),
+                        pos
+                );
+            });
+
+            cs.getSource().sendSuccess(
+                    () -> Component.translatable(
+                            "commands.place.template.success", Component.translationArg(template), pos.getX(), pos.getY(), pos.getZ()
+                    ),
+                    true
+            );
+            return 0;
+
+        } finally {
+            riftThemeData.setTheme(originalTheme);
+        }
+    }
+
+    public static int placeTemplate(ResourceLocation template, BlockPos
+            pos, List<StructureProcessor> processorList, Rotation rotation, Mirror mirror, int seed, CommandContext<
+            CommandSourceStack> cs) throws CommandSyntaxException {
         ServerLevel serverlevel = cs.getSource().getLevel();
         StructureTemplateManager structuretemplatemanager = serverlevel.getStructureManager();
 
@@ -238,7 +405,7 @@ public class SpawnPieceCommand {
             StructurePlaceSettings structureplacesettings = new StructurePlaceSettings().setMirror(mirror).setRotation(rotation);
             structureplacesettings.clearProcessors().setRandom(StructureBlockEntity.createRandom(seed));
 
-            for(StructureProcessor processor : processorList){
+            for (StructureProcessor processor : processorList) {
                 structureplacesettings.addProcessor(processor);
             }
 


### PR DESCRIPTION
### Summary

This pull request extends the SpawnPiece command with an option to fully process and inject POIs into a spawned room. 

### Usage instructions

The command is
```spawnpiece <room> withPOIs <theme> [<location>] [<includeTerminators>] [<seed>]```

This will spawn the room, processed by the provided theme. `location` determines the lower-corner of the room (so it will expand out into the +x, +y +z directions). `includeTermintors` determines whether the terminator pieces should be spawned, defaulting to true. `seed` is the random seed to spawn with, defaulting to a random value. 

### Implementation notes

Effectively the command spawns the room as a structure, but with depth 1 so that no further rooms are spawned.

### Possible areas for improvement

Rotation/mirroring cannot be controlled. This could be done via mixin to the Jigsaw system, or replicating and modifying jigsaw code perhaps.