### PR TITLE
Pat/implicits

### DIFF
--- a/src/main/java/com/wanderersoftherift/wotr/events/GearImplicitsTooltipEvent.java
+++ b/src/main/java/com/wanderersoftherift/wotr/events/GearImplicitsTooltipEvent.java
@@ -1,0 +1,55 @@
+package com.wanderersoftherift.wotr.events;
+
+
+import com.mojang.datafixers.util.Either;
+import com.wanderersoftherift.wotr.WanderersOfTheRift;
+import com.wanderersoftherift.wotr.client.tooltip.ImageTooltipRenderer;
+import com.wanderersoftherift.wotr.init.ModDataComponentType;
+import com.wanderersoftherift.wotr.item.implicit.GearImplicits;
+import com.wanderersoftherift.wotr.modifier.ModifierInstance;
+import net.minecraft.ChatFormatting;
+import net.minecraft.client.Minecraft;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.FormattedText;
+import net.minecraft.network.chat.MutableComponent;
+import net.minecraft.world.inventory.tooltip.TooltipComponent;
+import net.minecraft.world.item.ItemStack;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.client.event.RenderTooltipEvent;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@EventBusSubscriber(modid = WanderersOfTheRift.MODID, value = Dist.CLIENT, bus = EventBusSubscriber.Bus.GAME)
+public class GearImplicitsTooltipEvent {
+
+    @SubscribeEvent
+    public static void on(RenderTooltipEvent.GatherComponents event) {
+        List<Either<FormattedText, TooltipComponent>> list = event.getTooltipElements();
+        ItemStack stack = event.getItemStack();
+        if (!stack.has(ModDataComponentType.GEAR_IMPLICITS)) return;
+
+        GearImplicits implicits = stack.get(ModDataComponentType.GEAR_IMPLICITS);
+        if (implicits == null) return;
+        List<ModifierInstance> modifierInstances = implicits.modifierInstances(stack, Minecraft.getInstance().level);
+
+        List<TooltipComponent> toAdd = new ArrayList<>();
+
+        for (ModifierInstance modifierInstance : modifierInstances) {
+
+                float roll = modifierInstance.roll();
+                float roundedValue = (float) (Math.ceil(roll * 100) / 100);
+
+                // TODO: Hardcoded currently, need to see how the modifier stuff develops further
+                MutableComponent cmp = Component.literal("+" + roundedValue + " " + modifierInstance.modifier().getRegisteredName()).withStyle(ChatFormatting.AQUA);
+                toAdd.addLast(new ImageTooltipRenderer.ImageComponent(stack, cmp, WanderersOfTheRift.id("textures/tooltip/attribute/damage_attribute.png")));
+        }
+
+
+        for (int i = 0; i < toAdd.size(); i++) {
+            list.add(i + 1, Either.right(toAdd.get(i)));
+        }
+    }
+}

--- a/src/main/java/com/wanderersoftherift/wotr/init/ModDataComponentType.java
+++ b/src/main/java/com/wanderersoftherift/wotr/init/ModDataComponentType.java
@@ -3,6 +3,7 @@ package com.wanderersoftherift.wotr.init;
 import com.mojang.serialization.Codec;
 import com.wanderersoftherift.wotr.WanderersOfTheRift;
 import com.wanderersoftherift.wotr.item.LootBox;
+import com.wanderersoftherift.wotr.item.implicit.GearImplicits;
 import com.wanderersoftherift.wotr.item.runegem.RunegemData;
 import com.wanderersoftherift.wotr.item.socket.GearSockets;
 import net.minecraft.core.UUIDUtil;
@@ -22,6 +23,7 @@ public class ModDataComponentType {
     public static final DeferredRegister.DataComponents DATA_COMPONENTS = DeferredRegister.createDataComponents(Registries.DATA_COMPONENT_TYPE, WanderersOfTheRift.MODID);
 
     public static final DeferredHolder<DataComponentType<?>, DataComponentType<GearSockets>> GEAR_SOCKETS  = register("gear_sockets", GearSockets.CODEC, null);
+    public static final DeferredHolder<DataComponentType<?>, DataComponentType<GearImplicits>> GEAR_IMPLICITS = register("gear_implicits", GearImplicits.CODEC, null);
     public static final DeferredHolder<DataComponentType<?>, DataComponentType<RunegemData>> RUNEGEM_DATA  = register("runegem_data", RunegemData.CODEC, null);
     public static final DeferredHolder<DataComponentType<?>, DataComponentType<UUID>> INVENTORY_SNAPSHOT_ID = register("inventory_snapshot_id", UUIDUtil.CODEC, null);
     public static final DeferredHolder<DataComponentType<?>, DataComponentType<Integer>> RIFT_TIER = register("rift_tier", Codec.INT, ByteBufCodecs.INT);

--- a/src/main/java/com/wanderersoftherift/wotr/init/ModDatapackRegistries.java
+++ b/src/main/java/com/wanderersoftherift/wotr/init/ModDatapackRegistries.java
@@ -1,6 +1,7 @@
 package com.wanderersoftherift.wotr.init;
 
 import com.wanderersoftherift.wotr.WanderersOfTheRift;
+import com.wanderersoftherift.wotr.item.implicit.ImplicitConfig;
 import com.wanderersoftherift.wotr.item.runegem.RunegemData;
 import com.wanderersoftherift.wotr.modifier.Modifier;
 import net.minecraft.core.Registry;
@@ -10,4 +11,5 @@ public class ModDatapackRegistries {
 
     public static final ResourceKey<Registry<Modifier>> MODIFIER_KEY = ResourceKey.createRegistryKey(WanderersOfTheRift.id("modifier"));
     public static final ResourceKey<Registry<RunegemData>> RUNEGEM_DATA_KEY = ResourceKey.createRegistryKey(WanderersOfTheRift.id("runegem_data"));
+    public static final ResourceKey<Registry<ImplicitConfig>> GEAR_IMPLICITS_CONFIG = ResourceKey.createRegistryKey(WanderersOfTheRift.id("implicit_config"));
 }

--- a/src/main/java/com/wanderersoftherift/wotr/init/RegistryEvents.java
+++ b/src/main/java/com/wanderersoftherift/wotr/init/RegistryEvents.java
@@ -1,6 +1,7 @@
 package com.wanderersoftherift.wotr.init;
 
 import com.wanderersoftherift.wotr.WanderersOfTheRift;
+import com.wanderersoftherift.wotr.item.implicit.ImplicitConfig;
 import com.wanderersoftherift.wotr.item.runegem.RunegemData;
 import com.wanderersoftherift.wotr.modifier.Modifier;
 import com.wanderersoftherift.wotr.modifier.effect.AbstractModifierEffect;
@@ -41,6 +42,11 @@ public class RegistryEvents {
                 ModDatapackRegistries.RUNEGEM_DATA_KEY,
                 RunegemData.CODEC,
                 RunegemData.CODEC
+        );
+        event.dataPackRegistry(
+                ModDatapackRegistries.GEAR_IMPLICITS_CONFIG,
+                ImplicitConfig.CODEC,
+                ImplicitConfig.CODEC
         );
     }
 }

--- a/src/main/java/com/wanderersoftherift/wotr/item/implicit/GearImplicits.java
+++ b/src/main/java/com/wanderersoftherift/wotr/item/implicit/GearImplicits.java
@@ -1,0 +1,31 @@
+package com.wanderersoftherift.wotr.item.implicit;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import com.wanderersoftherift.wotr.init.ModDatapackRegistries;
+import com.wanderersoftherift.wotr.modifier.Modifier;
+import com.wanderersoftherift.wotr.modifier.ModifierInstance;
+import net.minecraft.core.HolderSet;
+import net.minecraft.core.RegistryCodecs;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
+
+import java.util.List;
+
+public interface GearImplicits {
+    Codec<GearImplicits> CODEC = RecordCodecBuilder.create(inst -> inst.group(
+            ModifierInstance.CODEC.listOf().optionalFieldOf("instances", List.of()).forGetter(GearImplicits::modifierInstances)
+    ).apply(inst, GearImplicits::of));
+
+    static GearImplicits of(List<ModifierInstance> modifierInstances) {
+        if(modifierInstances.isEmpty()){
+            return new UnrolledGearImplicits();
+        }else{
+            return new RolledGearImplicits(modifierInstances);
+        }
+    }
+
+    List<ModifierInstance> modifierInstances(ItemStack stack, Level level);
+
+    List<ModifierInstance> modifierInstances();
+}

--- a/src/main/java/com/wanderersoftherift/wotr/item/implicit/GearImplicitsModEvents.java
+++ b/src/main/java/com/wanderersoftherift/wotr/item/implicit/GearImplicitsModEvents.java
@@ -1,0 +1,28 @@
+package com.wanderersoftherift.wotr.item.implicit;
+
+import com.wanderersoftherift.wotr.init.ModDataComponentType;
+import com.wanderersoftherift.wotr.item.runegem.RunegemShape;
+import com.wanderersoftherift.wotr.item.socket.GearSocket;
+import com.wanderersoftherift.wotr.item.socket.GearSockets;
+import net.minecraft.world.item.Items;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.event.ModifyDefaultComponentsEvent;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.Optional;
+
+import static com.wanderersoftherift.wotr.WanderersOfTheRift.MODID;
+import static net.neoforged.fml.common.EventBusSubscriber.Bus;
+
+@EventBusSubscriber(bus = Bus.MOD, modid = MODID)
+public class GearImplicitsModEvents {
+
+    @SubscribeEvent
+    public static void modifyComponents(ModifyDefaultComponentsEvent event) {
+        event.modify(Items.WOODEN_SWORD, builder ->
+                builder.set(ModDataComponentType.GEAR_IMPLICITS.get(), new UnrolledGearImplicits())
+        );
+    }
+}

--- a/src/main/java/com/wanderersoftherift/wotr/item/implicit/ImplicitConfig.java
+++ b/src/main/java/com/wanderersoftherift/wotr/item/implicit/ImplicitConfig.java
@@ -1,0 +1,16 @@
+package com.wanderersoftherift.wotr.item.implicit;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import com.wanderersoftherift.wotr.init.ModDatapackRegistries;
+import com.wanderersoftherift.wotr.modifier.Modifier;
+import net.minecraft.core.Holder;
+import net.minecraft.core.HolderSet;
+import net.minecraft.core.RegistryCodecs;
+
+public record ImplicitConfig(HolderSet<Modifier> implicitModifiers) {
+    public static final ImplicitConfig DEFAULT = new ImplicitConfig(HolderSet.empty());
+    public static Codec<ImplicitConfig> CODEC = RecordCodecBuilder.create(inst -> inst.group(
+            RegistryCodecs.homogeneousList(ModDatapackRegistries.MODIFIER_KEY).fieldOf("modifiers").forGetter(ImplicitConfig::implicitModifiers)
+    ).apply(inst, ImplicitConfig::new));
+}

--- a/src/main/java/com/wanderersoftherift/wotr/item/implicit/RolledGearImplicits.java
+++ b/src/main/java/com/wanderersoftherift/wotr/item/implicit/RolledGearImplicits.java
@@ -1,0 +1,17 @@
+package com.wanderersoftherift.wotr.item.implicit;
+
+import com.wanderersoftherift.wotr.modifier.ModifierInstance;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
+
+import java.util.List;
+
+public record RolledGearImplicits(
+        List<ModifierInstance> modifierInstances
+) implements GearImplicits{
+
+    @Override
+    public List<ModifierInstance> modifierInstances(ItemStack stack, Level level) {
+        return List.copyOf(modifierInstances);
+    }
+}

--- a/src/main/java/com/wanderersoftherift/wotr/item/implicit/UnrolledGearImplicits.java
+++ b/src/main/java/com/wanderersoftherift/wotr/item/implicit/UnrolledGearImplicits.java
@@ -1,0 +1,47 @@
+package com.wanderersoftherift.wotr.item.implicit;
+
+import com.wanderersoftherift.wotr.init.ModDataComponentType;
+import com.wanderersoftherift.wotr.modifier.Modifier;
+import com.wanderersoftherift.wotr.modifier.ModifierInstance;
+import net.minecraft.core.Holder;
+import net.minecraft.core.Registry;
+import net.minecraft.util.RandomSource;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import static com.wanderersoftherift.wotr.init.ModDatapackRegistries.GEAR_IMPLICITS_CONFIG;
+
+public record UnrolledGearImplicits() implements GearImplicits {
+
+    @Override
+    public List<ModifierInstance> modifierInstances(ItemStack stack, Level level) {
+        if(level.isClientSide()) {
+            return List.of();
+        }
+        Registry<ImplicitConfig> implicitConfigs = level.registryAccess().lookupOrThrow(GEAR_IMPLICITS_CONFIG);
+        ImplicitConfig config = implicitConfigs.getOptional(stack.getItemHolder().getKey().location()).orElse(ImplicitConfig.DEFAULT);
+        if (config.implicitModifiers().size() == 0) {
+            return List.of();
+        }
+        List<ModifierInstance> instances = new ArrayList<>();
+        Iterator<Holder<Modifier>> iterator = config.implicitModifiers().iterator();
+        RandomSource randomSource = RandomSource.create();
+        randomSource.consumeCount(1);
+        while(iterator.hasNext()) {
+            Holder<Modifier> holder = iterator.next();
+            instances.add(ModifierInstance.of(holder, randomSource));
+        }
+        RolledGearImplicits rolledGearImplicits = new RolledGearImplicits(instances);
+        stack.set(ModDataComponentType.GEAR_IMPLICITS, rolledGearImplicits);
+        return instances;
+    }
+
+    @Override
+    public List<ModifierInstance> modifierInstances() {
+        return List.of();
+    }
+}

--- a/src/main/java/com/wanderersoftherift/wotr/modifier/source/GearImplicitModifierSource.java
+++ b/src/main/java/com/wanderersoftherift/wotr/modifier/source/GearImplicitModifierSource.java
@@ -1,0 +1,23 @@
+package com.wanderersoftherift.wotr.modifier.source;
+
+import com.wanderersoftherift.wotr.item.implicit.GearImplicits;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.EquipmentSlot;
+
+public class GearImplicitModifierSource implements ModifierSource {
+    private final GearImplicits implicits;
+    private final EquipmentSlot slot;
+    private final Entity entity;
+
+    public GearImplicitModifierSource(GearImplicits implicits, EquipmentSlot slot, Entity entity) {
+        this.implicits = implicits;
+        this.slot = slot;
+        this.entity = entity;
+    }
+
+
+    @Override
+    public String getSerializedName() {
+        return "implicits_" + slot.getSerializedName();
+    }
+}

--- a/src/main/resources/data/minecraft/wotr/implicit_config/wooden_sword.json
+++ b/src/main/resources/data/minecraft/wotr/implicit_config/wooden_sword.json
@@ -1,0 +1,5 @@
+{
+  "modifiers": [
+    "wotr:attack_speed_t1"
+  ]
+}


### PR DESCRIPTION
Adds implicits to items.

Items that need to get implicits, need to be added to ModifyDefaultComponentsEvent. Wooden Sword added as an example. Considering to change to a tag later.

There is a new registry, which contains the implicit configuration of an item, allowing configuration through datapack.