### PR TITLE
fix: Correct logger used by objective data to fix server startup failure

### DIFF
--- a/src/main/java/com/wanderersoftherift/wotr/rift/objective/LevelRiftObjectiveData.java
+++ b/src/main/java/com/wanderersoftherift/wotr/rift/objective/LevelRiftObjectiveData.java
@@ -8,7 +8,7 @@ import net.minecraft.nbt.NbtOps;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.saveddata.SavedData;
 
-import static com.mojang.text2speech.Narrator.LOGGER;
+import static com.wanderersoftherift.wotr.WanderersOfTheRift.LOGGER;
 
 
 public class LevelRiftObjectiveData extends SavedData {


### PR DESCRIPTION
Because Narrator is a client side only class.