### PR TITLE
feat: initial essence values for all vanilla items

### DIFF
--- a/src/generated/resources/assets/wotr/lang/en_us.json
+++ b/src/generated/resources/assets/wotr/lang/en_us.json
@@ -252,6 +252,7 @@
   "container.wotr.rune_anvil.apply": "Apply",
   "effect_marker.wotr.fireshield": "Fire Shield",
   "entity.wotr.rift_entrance": "Rift Entrance",
+  "entity.wotr.rift_exit": "Rift Egress",
   "entity.wotr.simple_effect_projectile": "Projectile",
   "essence_type.wotr.earth": "Earth",
   "essence_type.wotr.life": "Life",

--- a/src/generated/resources/data/wotr/data_maps/item/essence_value.json
+++ b/src/generated/resources/data/wotr/data_maps/item/essence_value.json
@@ -1,26 +1,2702 @@
 {
   "values": {
-    "#c:cobblestones": {
+    "#c:barrels/wooden": {
+      "wotr:order": 1,
+      "wotr:plant": 1
+    },
+    "#c:bricks/nether": {
+      "wotr:earth": 1,
+      "wotr:nether": 1
+    },
+    "#c:bricks/normal": {
       "wotr:earth": 1
     },
-    "#c:crops": {
+    "#c:chests/ender": {
+      "wotr:order": 1,
+      "wotr:space": 1
+    },
+    "#c:chests/wooden": {
+      "wotr:order": 1,
+      "wotr:plant": 1
+    },
+    "#c:cobblestones/deepslate": {
+      "wotr:earth": 1
+    },
+    "#c:cobblestones/mossy": {
+      "wotr:earth": 1,
+      "wotr:plant": 1
+    },
+    "#c:cobblestones/normal": {
+      "wotr:earth": 1
+    },
+    "#c:concrete_powders": {
+      "wotr:earth": 1
+    },
+    "#c:concretes": {
+      "wotr:earth": 1
+    },
+    "#c:dyes": {
+      "wotr:order": 1,
+      "wotr:water": 1
+    },
+    "#c:fence_gates/wooden": {
+      "wotr:order": 1,
+      "wotr:plant": 1
+    },
+    "#c:fences/nether_brick": {
+      "wotr:earth": 1,
+      "wotr:nether": 1
+    },
+    "#c:flowers/tall": {
+      "wotr:plant": 1
+    },
+    "#c:foods/cooked_fish": {
+      "wotr:animal": 1,
       "wotr:life": 1
     },
     "#c:foods/cooked_meat": {
-      "wotr:meat": 2
+      "wotr:animal": 1,
+      "wotr:life": 1
+    },
+    "#c:foods/raw_fish": {
+      "wotr:animal": 1,
+      "wotr:water": 1
     },
     "#c:foods/raw_meat": {
-      "wotr:meat": 1
+      "wotr:animal": 1
+    },
+    "#c:glass_blocks/cheap": {
+      "wotr:crystal": 1,
+      "wotr:earth": 1
+    },
+    "#c:glass_panes": {
+      "wotr:crystal": 1,
+      "wotr:earth": 1
+    },
+    "#c:glazed_terracottas": {
+      "wotr:earth": 1
+    },
+    "#c:ingots/copper": {
+      "wotr:metal": 1
+    },
+    "#c:ingots/gold": {
+      "wotr:metal": 1
+    },
+    "#c:ingots/iron": {
+      "wotr:metal": 1
+    },
+    "#c:ingots/netherite": {
+      "wotr:metal": 1,
+      "wotr:nether": 1
+    },
+    "#c:mushrooms": {
+      "wotr:life": 1
+    },
+    "#c:music_discs": {
+      "wotr:knowledge": 1,
+      "wotr:order": 1
+    },
+    "#c:ores/quartz": {
+      "wotr:crystal": 1,
+      "wotr:nether": 1
+    },
+    "#c:ores/redstone": {
+      "wotr:earth": 1,
+      "wotr:power": 1
+    },
+    "#c:potions": {
+      "wotr:knowledge": 1,
+      "wotr:water": 1
+    },
+    "#c:sandstone/blocks": {
+      "wotr:earth": 1
+    },
+    "#c:sandstone/slabs": {
+      "wotr:earth": 1
+    },
+    "#c:sandstone/stairs": {
+      "wotr:earth": 1
+    },
+    "#c:seeds": {
+      "wotr:life": 1,
+      "wotr:plant": 1
     },
     "#c:stones": {
-      "wotr:earth": 2
+      "wotr:earth": 1
     },
-    "#c:stripped_logs": {
-      "wotr:life": 8
+    "#c:tools/shield": {
+      "wotr:chaos": 1
+    },
+    "#minecraft:acacia_logs": {
+      "wotr:plant": 1
+    },
+    "#minecraft:anvil": {
+      "wotr:metal": 1,
+      "wotr:order": 1
+    },
+    "#minecraft:bamboo_blocks": {
+      "wotr:plant": 1
+    },
+    "#minecraft:banners": {
+      "wotr:fabric": 1,
+      "wotr:order": 1
+    },
+    "#minecraft:beds": {
+      "wotr:fabric": 1,
+      "wotr:order": 1
+    },
+    "#minecraft:birch_logs": {
+      "wotr:plant": 1
+    },
+    "#minecraft:boats": {
+      "wotr:order": 1,
+      "wotr:water": 1
+    },
+    "#minecraft:bundles": {
+      "wotr:animal": 1,
+      "wotr:order": 1
+    },
+    "#minecraft:candles": {
+      "wotr:animal": 1,
+      "wotr:light": 1
+    },
+    "#minecraft:cherry_logs": {
+      "wotr:plant": 1
+    },
+    "#minecraft:chest_boats": {
+      "wotr:order": 1,
+      "wotr:water": 1
+    },
+    "#minecraft:coal_ores": {
+      "wotr:earth": 1,
+      "wotr:fire": 1
+    },
+    "#minecraft:copper_ores": {
+      "wotr:earth": 1,
+      "wotr:metal": 1
+    },
+    "#minecraft:crimson_stems": {
+      "wotr:nether": 1,
+      "wotr:plant": 1
+    },
+    "#minecraft:dark_oak_logs": {
+      "wotr:plant": 1
+    },
+    "#minecraft:decorated_pot_sherds": {
+      "wotr:earth": 1,
+      "wotr:order": 1
+    },
+    "#minecraft:diamond_ores": {
+      "wotr:crystal": 1,
+      "wotr:earth": 1
+    },
+    "#minecraft:emerald_ores": {
+      "wotr:crystal": 1,
+      "wotr:earth": 1
+    },
+    "#minecraft:hanging_signs": {
+      "wotr:order": 1,
+      "wotr:plant": 1
+    },
+    "#minecraft:iron_ores": {
+      "wotr:earth": 1,
+      "wotr:metal": 1
+    },
+    "#minecraft:jungle_logs": {
+      "wotr:plant": 1
+    },
+    "#minecraft:lapis_ores": {
+      "wotr:crystal": 1,
+      "wotr:earth": 1
+    },
+    "#minecraft:leaves": {
+      "wotr:plant": 1
+    },
+    "#minecraft:mangrove_logs": {
+      "wotr:plant": 1
+    },
+    "#minecraft:oak_logs": {
+      "wotr:plant": 1
+    },
+    "#minecraft:pale_oak_logs": {
+      "wotr:plant": 1
+    },
+    "#minecraft:planks": {
+      "wotr:plant": 1
+    },
+    "#minecraft:sand": {
+      "wotr:earth": 1
+    },
+    "#minecraft:saplings": {
+      "wotr:life": 1,
+      "wotr:plant": 1
+    },
+    "#minecraft:shulker_boxes": {
+      "wotr:end": 1,
+      "wotr:order": 1
+    },
+    "#minecraft:signs": {
+      "wotr:order": 1,
+      "wotr:plant": 1
+    },
+    "#minecraft:skulls": {
+      "wotr:death": 1
+    },
+    "#minecraft:spruce_logs": {
+      "wotr:plant": 1
+    },
+    "#minecraft:stone_bricks": {
+      "wotr:earth": 1
+    },
+    "#minecraft:stone_buttons": {
+      "wotr:earth": 1
+    },
+    "#minecraft:terracotta": {
+      "wotr:earth": 1
+    },
+    "#minecraft:warped_stems": {
+      "wotr:nether": 1,
+      "wotr:plant": 1
+    },
+    "#minecraft:wart_blocks": {
+      "wotr:nether": 1,
+      "wotr:plant": 1
+    },
+    "#minecraft:wooden_buttons": {
+      "wotr:order": 1,
+      "wotr:plant": 1
+    },
+    "#minecraft:wooden_doors": {
+      "wotr:order": 1,
+      "wotr:plant": 1
+    },
+    "#minecraft:wooden_fences": {
+      "wotr:order": 1,
+      "wotr:plant": 1
+    },
+    "#minecraft:wooden_pressure_plates": {
+      "wotr:order": 1,
+      "wotr:plant": 1
+    },
+    "#minecraft:wooden_slabs": {
+      "wotr:plant": 1
+    },
+    "#minecraft:wooden_stairs": {
+      "wotr:plant": 1
+    },
+    "#minecraft:wooden_trapdoors": {
+      "wotr:order": 1,
+      "wotr:plant": 1
+    },
+    "#minecraft:wool": {
+      "wotr:fabric": 1
+    },
+    "#minecraft:wool_carpets": {
+      "wotr:fabric": 1
+    },
+    "minecraft:activator_rail": {
+      "wotr:order": 1,
+      "wotr:power": 1
+    },
+    "minecraft:allium": {
+      "wotr:life": 1,
+      "wotr:plant": 1
+    },
+    "minecraft:amethyst_block": {
+      "wotr:crystal": 1
+    },
+    "minecraft:amethyst_cluster": {
+      "wotr:crystal": 1
+    },
+    "minecraft:amethyst_shard": {
+      "wotr:crystal": 1
+    },
+    "minecraft:ancient_debris": {
+      "wotr:metal": 1,
+      "wotr:nether": 1
+    },
+    "minecraft:andesite_slab": {
+      "wotr:earth": 1
+    },
+    "minecraft:andesite_stairs": {
+      "wotr:earth": 1
+    },
+    "minecraft:andesite_wall": {
+      "wotr:earth": 1
+    },
+    "minecraft:apple": {
+      "wotr:life": 1,
+      "wotr:plant": 1
+    },
+    "minecraft:armadillo_scute": {
+      "wotr:animal": 1
+    },
+    "minecraft:armor_stand": {
+      "wotr:order": 1
+    },
+    "minecraft:arrow": {
+      "wotr:air": 1,
+      "wotr:chaos": 1
+    },
+    "minecraft:axolotl_bucket": {
+      "wotr:animal": 1,
+      "wotr:water": 1
+    },
+    "minecraft:azure_bluet": {
+      "wotr:life": 1,
+      "wotr:plant": 1
+    },
+    "minecraft:baked_potato": {
+      "wotr:life": 1,
+      "wotr:plant": 1
+    },
+    "minecraft:bamboo": {
+      "wotr:plant": 1
+    },
+    "minecraft:bamboo_mosaic": {
+      "wotr:plant": 1
+    },
+    "minecraft:bamboo_mosaic_slab": {
+      "wotr:plant": 1
+    },
+    "minecraft:bamboo_mosaic_stairs": {
+      "wotr:plant": 1
+    },
+    "minecraft:basalt": {
+      "wotr:earth": 1,
+      "wotr:fire": 1
+    },
+    "minecraft:beacon": {
+      "wotr:crystal": 1,
+      "wotr:knowledge": 1
+    },
+    "minecraft:bee_nest": {
+      "wotr:animal": 1,
+      "wotr:order": 1
+    },
+    "minecraft:beehive": {
+      "wotr:animal": 1,
+      "wotr:order": 1
+    },
+    "minecraft:beetroot": {
+      "wotr:life": 1,
+      "wotr:plant": 1
+    },
+    "minecraft:beetroot_soup": {
+      "wotr:life": 1,
+      "wotr:plant": 1
+    },
+    "minecraft:bell": {
+      "wotr:metal": 1
+    },
+    "minecraft:big_dripleaf": {
+      "wotr:plant": 1
+    },
+    "minecraft:blackstone": {
+      "wotr:earth": 1
+    },
+    "minecraft:blackstone_slab": {
+      "wotr:earth": 1
+    },
+    "minecraft:blackstone_stairs": {
+      "wotr:earth": 1
+    },
+    "minecraft:blackstone_wall": {
+      "wotr:earth": 1
+    },
+    "minecraft:blast_furnace": {
+      "wotr:fire": 1
+    },
+    "minecraft:blaze_powder": {
+      "wotr:fire": 1
+    },
+    "minecraft:blaze_rod": {
+      "wotr:fire": 1
+    },
+    "minecraft:blue_ice": {
+      "wotr:water": 1
+    },
+    "minecraft:blue_orchid": {
+      "wotr:life": 1,
+      "wotr:plant": 1
+    },
+    "minecraft:bolt_armor_trim_smithing_template": {
+      "wotr:knowledge": 1
+    },
+    "minecraft:bone": {
+      "wotr:animal": 1,
+      "wotr:death": 1
+    },
+    "minecraft:bone_block": {
+      "wotr:animal": 1,
+      "wotr:death": 1
+    },
+    "minecraft:bone_meal": {
+      "wotr:animal": 1,
+      "wotr:death": 1
+    },
+    "minecraft:book": {
+      "wotr:knowledge": 1
+    },
+    "minecraft:bookshelf": {
+      "wotr:knowledge": 1,
+      "wotr:order": 1
+    },
+    "minecraft:bordure_indented_banner_pattern": {
+      "wotr:fabric": 1,
+      "wotr:knowledge": 1
+    },
+    "minecraft:bow": {
+      "wotr:air": 1,
+      "wotr:chaos": 1
+    },
+    "minecraft:bowl": {
+      "wotr:plant": 1
+    },
+    "minecraft:brain_coral": {
+      "wotr:plant": 1,
+      "wotr:water": 1
+    },
+    "minecraft:brain_coral_block": {
+      "wotr:plant": 1,
+      "wotr:water": 1
+    },
+    "minecraft:brain_coral_fan": {
+      "wotr:plant": 1,
+      "wotr:water": 1
+    },
+    "minecraft:bread": {
+      "wotr:life": 1
+    },
+    "minecraft:breeze_rod": {
+      "wotr:air": 1
+    },
+    "minecraft:brewing_stand": {
+      "wotr:knowledge": 1,
+      "wotr:order": 1
+    },
+    "minecraft:brick_slab": {
+      "wotr:earth": 1
+    },
+    "minecraft:brick_stairs": {
+      "wotr:earth": 1
+    },
+    "minecraft:brick_wall": {
+      "wotr:earth": 1
+    },
+    "minecraft:bricks": {
+      "wotr:earth": 1
+    },
+    "minecraft:brown_mushroom_block": {
+      "wotr:life": 1
+    },
+    "minecraft:brush": {
+      "wotr:order": 1
+    },
+    "minecraft:bubble_coral": {
+      "wotr:plant": 1,
+      "wotr:water": 1
+    },
+    "minecraft:bubble_coral_block": {
+      "wotr:plant": 1,
+      "wotr:water": 1
+    },
+    "minecraft:bubble_coral_fan": {
+      "wotr:plant": 1,
+      "wotr:water": 1
+    },
+    "minecraft:bucket": {
+      "wotr:metal": 1
+    },
+    "minecraft:cactus": {
+      "wotr:life": 1,
+      "wotr:plant": 1
+    },
+    "minecraft:cake": {
+      "wotr:life": 1
+    },
+    "minecraft:calcite": {
+      "wotr:earth": 1
+    },
+    "minecraft:calibrated_sculk_sensor": {
+      "wotr:crystal": 1,
+      "wotr:dark": 1
+    },
+    "minecraft:campfire": {
+      "wotr:fire": 1,
+      "wotr:light": 1
+    },
+    "minecraft:carrot": {
+      "wotr:life": 1,
+      "wotr:plant": 1
+    },
+    "minecraft:carrot_on_a_stick": {
+      "wotr:plant": 1
+    },
+    "minecraft:cartography_table": {
+      "wotr:order": 1,
+      "wotr:space": 1
+    },
+    "minecraft:carved_pumpkin": {
+      "wotr:plant": 1
+    },
+    "minecraft:cauldron": {
+      "wotr:metal": 1
+    },
+    "minecraft:chain": {
+      "wotr:metal": 1
+    },
+    "minecraft:chainmail_boots": {
+      "wotr:metal": 1
+    },
+    "minecraft:chainmail_chestplate": {
+      "wotr:metal": 1
+    },
+    "minecraft:chainmail_helmet": {
+      "wotr:metal": 1
+    },
+    "minecraft:chainmail_leggings": {
+      "wotr:metal": 1
+    },
+    "minecraft:charcoal": {
+      "wotr:earth": 1,
+      "wotr:fire": 1
+    },
+    "minecraft:chest_minecart": {
+      "wotr:order": 1
+    },
+    "minecraft:chiseled_bookshelf": {
+      "wotr:knowledge": 1,
+      "wotr:order": 1
+    },
+    "minecraft:chiseled_copper": {
+      "wotr:metal": 1
+    },
+    "minecraft:chiseled_deepslate": {
+      "wotr:earth": 1
+    },
+    "minecraft:chiseled_nether_bricks": {
+      "wotr:earth": 1,
+      "wotr:nether": 1
+    },
+    "minecraft:chiseled_polished_blackstone": {
+      "wotr:earth": 1
+    },
+    "minecraft:chiseled_quartz_block": {
+      "wotr:crystal": 1,
+      "wotr:nether": 1
+    },
+    "minecraft:chiseled_resin_bricks": {
+      "wotr:crystal": 1,
+      "wotr:plant": 1
+    },
+    "minecraft:chiseled_tuff": {
+      "wotr:earth": 1
+    },
+    "minecraft:chiseled_tuff_bricks": {
+      "wotr:earth": 1
+    },
+    "minecraft:chorus_flower": {
+      "wotr:end": 1,
+      "wotr:plant": 1
+    },
+    "minecraft:chorus_fruit": {
+      "wotr:end": 1,
+      "wotr:plant": 1,
+      "wotr:space": 1
+    },
+    "minecraft:chorus_plant": {
+      "wotr:end": 1,
+      "wotr:plant": 1
+    },
+    "minecraft:clay": {
+      "wotr:earth": 1
+    },
+    "minecraft:clay_ball": {
+      "wotr:earth": 1
+    },
+    "minecraft:clock": {
+      "wotr:time": 1
+    },
+    "minecraft:closed_eyeblossom": {
+      "wotr:dark": 1,
+      "wotr:plant": 1
+    },
+    "minecraft:coal": {
+      "wotr:earth": 1,
+      "wotr:fire": 1
+    },
+    "minecraft:coal_block": {
+      "wotr:earth": 1,
+      "wotr:fire": 1
+    },
+    "minecraft:coarse_dirt": {
+      "wotr:earth": 1
+    },
+    "minecraft:coast_armor_trim_smithing_template": {
+      "wotr:knowledge": 1
+    },
+    "minecraft:cobbled_deepslate_slab": {
+      "wotr:earth": 1
+    },
+    "minecraft:cobbled_deepslate_stairs": {
+      "wotr:earth": 1
+    },
+    "minecraft:cobbled_deepslate_wall": {
+      "wotr:earth": 1
+    },
+    "minecraft:cobblestone_slab": {
+      "wotr:earth": 1
+    },
+    "minecraft:cobblestone_stairs": {
+      "wotr:earth": 1
+    },
+    "minecraft:cobblestone_wall": {
+      "wotr:earth": 1
+    },
+    "minecraft:cobweb": {
+      "wotr:animal": 1,
+      "wotr:fabric": 1
+    },
+    "minecraft:cocoa_beans": {
+      "wotr:life": 1,
+      "wotr:plant": 1
+    },
+    "minecraft:cod_bucket": {
+      "wotr:animal": 1,
+      "wotr:water": 1
+    },
+    "minecraft:comparator": {
+      "wotr:power": 1
+    },
+    "minecraft:compass": {
+      "wotr:power": 1,
+      "wotr:space": 1
+    },
+    "minecraft:composter": {
+      "wotr:life": 1,
+      "wotr:plant": 1
+    },
+    "minecraft:conduit": {
+      "wotr:knowledge": 1,
+      "wotr:water": 1
+    },
+    "minecraft:cookie": {
+      "wotr:life": 1
+    },
+    "minecraft:copper_block": {
+      "wotr:metal": 1
+    },
+    "minecraft:copper_bulb": {
+      "wotr:light": 1,
+      "wotr:metal": 1
+    },
+    "minecraft:copper_door": {
+      "wotr:metal": 1,
+      "wotr:order": 1
+    },
+    "minecraft:copper_grate": {
+      "wotr:metal": 1,
+      "wotr:order": 1
+    },
+    "minecraft:copper_trapdoor": {
+      "wotr:metal": 1,
+      "wotr:order": 1
+    },
+    "minecraft:cornflower": {
+      "wotr:life": 1,
+      "wotr:plant": 1
+    },
+    "minecraft:cracked_deepslate_bricks": {
+      "wotr:earth": 1
+    },
+    "minecraft:cracked_deepslate_tiles": {
+      "wotr:earth": 1
+    },
+    "minecraft:cracked_nether_bricks": {
+      "wotr:earth": 1,
+      "wotr:nether": 1
+    },
+    "minecraft:cracked_polished_blackstone_bricks": {
+      "wotr:earth": 1
+    },
+    "minecraft:crafter": {
+      "wotr:order": 1,
+      "wotr:power": 1
+    },
+    "minecraft:crafting_table": {
+      "wotr:order": 1
+    },
+    "minecraft:creaking_heart": {
+      "wotr:life": 1,
+      "wotr:plant": 1
+    },
+    "minecraft:creeper_banner_pattern": {
+      "wotr:fabric": 1,
+      "wotr:knowledge": 1
+    },
+    "minecraft:crimson_fungus": {
+      "wotr:life": 1,
+      "wotr:nether": 1
+    },
+    "minecraft:crimson_nylium": {
+      "wotr:earth": 1,
+      "wotr:nether": 1
+    },
+    "minecraft:crimson_roots": {
+      "wotr:nether": 1,
+      "wotr:plant": 1
+    },
+    "minecraft:crossbow": {
+      "wotr:air": 1,
+      "wotr:chaos": 1
+    },
+    "minecraft:crying_obsidian": {
+      "wotr:earth": 1,
+      "wotr:fire": 1
+    },
+    "minecraft:cut_copper": {
+      "wotr:metal": 1
+    },
+    "minecraft:cut_copper_slab": {
+      "wotr:metal": 1
+    },
+    "minecraft:cut_copper_stairs": {
+      "wotr:metal": 1
+    },
+    "minecraft:dandelion": {
+      "wotr:life": 1,
+      "wotr:plant": 1
+    },
+    "minecraft:dark_prismarine": {
+      "wotr:crystal": 1,
+      "wotr:water": 1
+    },
+    "minecraft:dark_prismarine_slab": {
+      "wotr:crystal": 1,
+      "wotr:water": 1
+    },
+    "minecraft:dark_prismarine_stairs": {
+      "wotr:crystal": 1,
+      "wotr:order": 1,
+      "wotr:water": 1
+    },
+    "minecraft:daylight_detector": {
+      "wotr:power": 1
+    },
+    "minecraft:dead_brain_coral": {
+      "wotr:plant": 1,
+      "wotr:water": 1
+    },
+    "minecraft:dead_brain_coral_block": {
+      "wotr:plant": 1,
+      "wotr:water": 1
+    },
+    "minecraft:dead_brain_coral_fan": {
+      "wotr:plant": 1,
+      "wotr:water": 1
+    },
+    "minecraft:dead_bubble_coral": {
+      "wotr:plant": 1,
+      "wotr:water": 1
+    },
+    "minecraft:dead_bubble_coral_block": {
+      "wotr:plant": 1,
+      "wotr:water": 1
+    },
+    "minecraft:dead_bubble_coral_fan": {
+      "wotr:plant": 1,
+      "wotr:water": 1
+    },
+    "minecraft:dead_bush": {
+      "wotr:plant": 1
+    },
+    "minecraft:dead_fire_coral": {
+      "wotr:plant": 1,
+      "wotr:water": 1
+    },
+    "minecraft:dead_fire_coral_block": {
+      "wotr:plant": 1,
+      "wotr:water": 1
+    },
+    "minecraft:dead_fire_coral_fan": {
+      "wotr:plant": 1,
+      "wotr:water": 1
+    },
+    "minecraft:dead_horn_coral": {
+      "wotr:plant": 1,
+      "wotr:water": 1
+    },
+    "minecraft:dead_horn_coral_block": {
+      "wotr:plant": 1,
+      "wotr:water": 1
+    },
+    "minecraft:dead_horn_coral_fan": {
+      "wotr:plant": 1,
+      "wotr:water": 1
+    },
+    "minecraft:dead_tube_coral": {
+      "wotr:plant": 1,
+      "wotr:water": 1
+    },
+    "minecraft:dead_tube_coral_block": {
+      "wotr:plant": 1,
+      "wotr:water": 1
+    },
+    "minecraft:dead_tube_coral_fan": {
+      "wotr:plant": 1,
+      "wotr:water": 1
+    },
+    "minecraft:decorated_pot": {
+      "wotr:earth": 1,
+      "wotr:order": 1
+    },
+    "minecraft:deepslate_brick_slab": {
+      "wotr:earth": 1
+    },
+    "minecraft:deepslate_brick_stairs": {
+      "wotr:earth": 1
+    },
+    "minecraft:deepslate_brick_wall": {
+      "wotr:earth": 1
+    },
+    "minecraft:deepslate_bricks": {
+      "wotr:earth": 1
+    },
+    "minecraft:deepslate_gold_ore": {
+      "wotr:earth": 1,
+      "wotr:metal": 1
+    },
+    "minecraft:deepslate_tile_slab": {
+      "wotr:earth": 1
+    },
+    "minecraft:deepslate_tile_stairs": {
+      "wotr:earth": 1
+    },
+    "minecraft:deepslate_tile_wall": {
+      "wotr:earth": 1
+    },
+    "minecraft:deepslate_tiles": {
+      "wotr:earth": 1
+    },
+    "minecraft:detector_rail": {
+      "wotr:order": 1,
+      "wotr:power": 1
+    },
+    "minecraft:diamond": {
+      "wotr:crystal": 1
+    },
+    "minecraft:diamond_axe": {
+      "wotr:chaos": 1,
+      "wotr:crystal": 1
+    },
+    "minecraft:diamond_block": {
+      "wotr:crystal": 1
+    },
+    "minecraft:diamond_boots": {
+      "wotr:crystal": 1
+    },
+    "minecraft:diamond_chestplate": {
+      "wotr:crystal": 1
+    },
+    "minecraft:diamond_helmet": {
+      "wotr:crystal": 1
+    },
+    "minecraft:diamond_hoe": {
+      "wotr:crystal": 1,
+      "wotr:life": 1
+    },
+    "minecraft:diamond_horse_armor": {
+      "wotr:crystal": 1
+    },
+    "minecraft:diamond_leggings": {
+      "wotr:crystal": 1
+    },
+    "minecraft:diamond_pickaxe": {
+      "wotr:crystal": 1,
+      "wotr:earth": 1
+    },
+    "minecraft:diamond_shovel": {
+      "wotr:crystal": 1,
+      "wotr:earth": 1
+    },
+    "minecraft:diamond_sword": {
+      "wotr:chaos": 1,
+      "wotr:crystal": 1
+    },
+    "minecraft:diorite_slab": {
+      "wotr:earth": 1
+    },
+    "minecraft:diorite_stairs": {
+      "wotr:earth": 1
+    },
+    "minecraft:diorite_wall": {
+      "wotr:earth": 1
+    },
+    "minecraft:dirt": {
+      "wotr:earth": 1
+    },
+    "minecraft:disc_fragment_5": {
+      "wotr:knowledge": 1,
+      "wotr:order": 1
+    },
+    "minecraft:dispenser": {
+      "wotr:power": 1
+    },
+    "minecraft:dragon_breath": {
+      "wotr:end": 1
+    },
+    "minecraft:dragon_egg": {
+      "wotr:end": 1,
+      "wotr:life": 1
+    },
+    "minecraft:dried_kelp": {
+      "wotr:plant": 1
+    },
+    "minecraft:dried_kelp_block": {
+      "wotr:plant": 1
+    },
+    "minecraft:dripstone_block": {
+      "wotr:earth": 1
+    },
+    "minecraft:dropper": {
+      "wotr:power": 1
+    },
+    "minecraft:dune_armor_trim_smithing_template": {
+      "wotr:knowledge": 1
+    },
+    "minecraft:echo_shard": {
+      "wotr:crystal": 1,
+      "wotr:dark": 1
+    },
+    "minecraft:egg": {
+      "wotr:animal": 1,
+      "wotr:life": 1
+    },
+    "minecraft:elytra": {
+      "wotr:air": 1
+    },
+    "minecraft:emerald": {
+      "wotr:crystal": 1
+    },
+    "minecraft:emerald_block": {
+      "wotr:crystal": 1
+    },
+    "minecraft:enchanted_book": {
+      "wotr:knowledge": 1
+    },
+    "minecraft:enchanted_golden_apple": {
+      "wotr:knowledge": 1,
+      "wotr:plant": 1
+    },
+    "minecraft:enchanting_table": {
+      "wotr:knowledge": 1
+    },
+    "minecraft:end_crystal": {
+      "wotr:crystal": 1,
+      "wotr:end": 1
+    },
+    "minecraft:end_rod": {
+      "wotr:end": 1
+    },
+    "minecraft:end_stone": {
+      "wotr:earth": 1,
+      "wotr:end": 1
+    },
+    "minecraft:end_stone_brick_slab": {
+      "wotr:earth": 1,
+      "wotr:end": 1
+    },
+    "minecraft:end_stone_brick_stairs": {
+      "wotr:earth": 1,
+      "wotr:end": 1
+    },
+    "minecraft:end_stone_brick_wall": {
+      "wotr:earth": 1,
+      "wotr:end": 1
+    },
+    "minecraft:end_stone_bricks": {
+      "wotr:earth": 1,
+      "wotr:end": 1
+    },
+    "minecraft:ender_eye": {
+      "wotr:knowledge": 1,
+      "wotr:space": 1
+    },
+    "minecraft:ender_pearl": {
+      "wotr:end": 1,
+      "wotr:space": 1
+    },
+    "minecraft:experience_bottle": {
+      "wotr:knowledge": 1
+    },
+    "minecraft:exposed_chiseled_copper": {
+      "wotr:metal": 1
+    },
+    "minecraft:exposed_copper": {
+      "wotr:metal": 1
+    },
+    "minecraft:exposed_copper_bulb": {
+      "wotr:light": 1,
+      "wotr:metal": 1
+    },
+    "minecraft:exposed_copper_door": {
+      "wotr:metal": 1,
+      "wotr:order": 1
+    },
+    "minecraft:exposed_copper_grate": {
+      "wotr:metal": 1,
+      "wotr:order": 1
+    },
+    "minecraft:exposed_copper_trapdoor": {
+      "wotr:metal": 1,
+      "wotr:order": 1
+    },
+    "minecraft:exposed_cut_copper": {
+      "wotr:metal": 1
+    },
+    "minecraft:exposed_cut_copper_slab": {
+      "wotr:metal": 1
+    },
+    "minecraft:exposed_cut_copper_stairs": {
+      "wotr:metal": 1
+    },
+    "minecraft:eye_armor_trim_smithing_template": {
+      "wotr:knowledge": 1
+    },
+    "minecraft:feather": {
+      "wotr:air": 1,
+      "wotr:animal": 1
+    },
+    "minecraft:fermented_spider_eye": {
+      "wotr:animal": 1
+    },
+    "minecraft:fern": {
+      "wotr:plant": 1
+    },
+    "minecraft:field_masoned_banner_pattern": {
+      "wotr:fabric": 1,
+      "wotr:knowledge": 1
+    },
+    "minecraft:filled_map": {
+      "wotr:knowledge": 1,
+      "wotr:space": 1
+    },
+    "minecraft:fire_charge": {
+      "wotr:fire": 1
+    },
+    "minecraft:fire_coral": {
+      "wotr:plant": 1,
+      "wotr:water": 1
+    },
+    "minecraft:fire_coral_block": {
+      "wotr:plant": 1,
+      "wotr:water": 1
+    },
+    "minecraft:fire_coral_fan": {
+      "wotr:plant": 1,
+      "wotr:water": 1
+    },
+    "minecraft:firework_rocket": {
+      "wotr:fire": 1
+    },
+    "minecraft:firework_star": {
+      "wotr:fire": 1
+    },
+    "minecraft:fishing_rod": {
+      "wotr:order": 1,
+      "wotr:plant": 1
+    },
+    "minecraft:fletching_table": {
+      "wotr:air": 1,
+      "wotr:order": 1
+    },
+    "minecraft:flint": {
+      "wotr:earth": 1
+    },
+    "minecraft:flint_and_steel": {
+      "wotr:fire": 1,
+      "wotr:metal": 1
+    },
+    "minecraft:flow_armor_trim_smithing_template": {
+      "wotr:knowledge": 1
+    },
+    "minecraft:flow_banner_pattern": {
+      "wotr:fabric": 1,
+      "wotr:knowledge": 1
+    },
+    "minecraft:flower_banner_pattern": {
+      "wotr:fabric": 1,
+      "wotr:knowledge": 1
+    },
+    "minecraft:flower_pot": {
+      "wotr:order": 1,
+      "wotr:plant": 1
+    },
+    "minecraft:furnace": {
+      "wotr:fire": 1
+    },
+    "minecraft:furnace_minecart": {
+      "wotr:fire": 1,
+      "wotr:order": 1
+    },
+    "minecraft:ghast_tear": {
+      "wotr:death": 1,
+      "wotr:nether": 1
+    },
+    "minecraft:gilded_blackstone": {
+      "wotr:earth": 1,
+      "wotr:metal": 1
+    },
+    "minecraft:glass_bottle": {
+      "wotr:crystal": 1,
+      "wotr:earth": 1
+    },
+    "minecraft:glistering_melon_slice": {
+      "wotr:life": 1,
+      "wotr:metal": 1
+    },
+    "minecraft:globe_banner_pattern": {
+      "wotr:fabric": 1,
+      "wotr:knowledge": 1
+    },
+    "minecraft:glow_berries": {
+      "wotr:light": 1,
+      "wotr:plant": 1
+    },
+    "minecraft:glow_ink_sac": {
+      "wotr:animal": 1,
+      "wotr:light": 1
+    },
+    "minecraft:glow_item_frame": {
+      "wotr:light": 1,
+      "wotr:order": 1
+    },
+    "minecraft:glow_lichen": {
+      "wotr:life": 1,
+      "wotr:light": 1
+    },
+    "minecraft:glowstone": {
+      "wotr:light": 1,
+      "wotr:nether": 1
+    },
+    "minecraft:glowstone_dust": {
+      "wotr:light": 1,
+      "wotr:nether": 1
+    },
+    "minecraft:goat_horn": {
+      "wotr:animal": 1,
+      "wotr:order": 1
+    },
+    "minecraft:gold_block": {
+      "wotr:metal": 1
+    },
+    "minecraft:gold_nugget": {
+      "wotr:metal": 1
+    },
+    "minecraft:gold_ore": {
+      "wotr:earth": 1,
+      "wotr:metal": 1
+    },
+    "minecraft:golden_apple": {
+      "wotr:life": 1,
+      "wotr:metal": 1
+    },
+    "minecraft:golden_axe": {
+      "wotr:chaos": 1,
+      "wotr:metal": 1
+    },
+    "minecraft:golden_boots": {
+      "wotr:metal": 1
+    },
+    "minecraft:golden_carrot": {
+      "wotr:life": 1,
+      "wotr:metal": 1
+    },
+    "minecraft:golden_chestplate": {
+      "wotr:metal": 1
+    },
+    "minecraft:golden_helmet": {
+      "wotr:metal": 1
+    },
+    "minecraft:golden_hoe": {
+      "wotr:life": 1,
+      "wotr:metal": 1
+    },
+    "minecraft:golden_horse_armor": {
+      "wotr:metal": 1
+    },
+    "minecraft:golden_leggings": {
+      "wotr:metal": 1
+    },
+    "minecraft:golden_pickaxe": {
+      "wotr:earth": 1,
+      "wotr:metal": 1
+    },
+    "minecraft:golden_shovel": {
+      "wotr:earth": 1,
+      "wotr:metal": 1
+    },
+    "minecraft:golden_sword": {
+      "wotr:chaos": 1,
+      "wotr:metal": 1
+    },
+    "minecraft:granite_slab": {
+      "wotr:earth": 1
+    },
+    "minecraft:granite_stairs": {
+      "wotr:earth": 1
+    },
+    "minecraft:granite_wall": {
+      "wotr:earth": 1
+    },
+    "minecraft:grass_block": {
+      "wotr:earth": 1,
+      "wotr:plant": 1
+    },
+    "minecraft:gravel": {
+      "wotr:earth": 1
+    },
+    "minecraft:grindstone": {
+      "wotr:chaos": 1,
+      "wotr:earth": 1
+    },
+    "minecraft:gunpowder": {
+      "wotr:fire": 1
+    },
+    "minecraft:guster_banner_pattern": {
+      "wotr:fabric": 1,
+      "wotr:knowledge": 1
+    },
+    "minecraft:hanging_roots": {
+      "wotr:plant": 1
+    },
+    "minecraft:hay_block": {
+      "wotr:life": 1,
+      "wotr:plant": 1
+    },
+    "minecraft:heart_of_the_sea": {
+      "wotr:crystal": 1,
+      "wotr:water": 1
+    },
+    "minecraft:heavy_core": {
+      "wotr:metal": 1
+    },
+    "minecraft:heavy_weighted_pressure_plate": {
+      "wotr:earth": 1
+    },
+    "minecraft:honey_block": {
+      "wotr:life": 1,
+      "wotr:water": 1
+    },
+    "minecraft:honey_bottle": {
+      "wotr:life": 1,
+      "wotr:water": 1
+    },
+    "minecraft:honeycomb": {
+      "wotr:life": 1,
+      "wotr:order": 1
+    },
+    "minecraft:honeycomb_block": {
+      "wotr:life": 1,
+      "wotr:order": 1
+    },
+    "minecraft:hopper": {
+      "wotr:metal": 1
+    },
+    "minecraft:hopper_minecart": {
+      "wotr:metal": 1,
+      "wotr:order": 1
+    },
+    "minecraft:horn_coral": {
+      "wotr:plant": 1,
+      "wotr:water": 1
+    },
+    "minecraft:horn_coral_block": {
+      "wotr:plant": 1,
+      "wotr:water": 1
+    },
+    "minecraft:horn_coral_fan": {
+      "wotr:plant": 1,
+      "wotr:water": 1
+    },
+    "minecraft:host_armor_trim_smithing_template": {
+      "wotr:knowledge": 1
+    },
+    "minecraft:ice": {
+      "wotr:water": 1
+    },
+    "minecraft:ink_sac": {
+      "wotr:animal": 1,
+      "wotr:water": 1
+    },
+    "minecraft:iron_axe": {
+      "wotr:chaos": 1,
+      "wotr:metal": 1
+    },
+    "minecraft:iron_bars": {
+      "wotr:metal": 1
+    },
+    "minecraft:iron_block": {
+      "wotr:metal": 1
+    },
+    "minecraft:iron_boots": {
+      "wotr:metal": 1
+    },
+    "minecraft:iron_chestplate": {
+      "wotr:metal": 1
+    },
+    "minecraft:iron_door": {
+      "wotr:metal": 1,
+      "wotr:order": 1
+    },
+    "minecraft:iron_helmet": {
+      "wotr:metal": 1
+    },
+    "minecraft:iron_hoe": {
+      "wotr:life": 1,
+      "wotr:metal": 1
+    },
+    "minecraft:iron_horse_armor": {
+      "wotr:metal": 1
+    },
+    "minecraft:iron_leggings": {
+      "wotr:metal": 1
+    },
+    "minecraft:iron_nugget": {
+      "wotr:metal": 1
+    },
+    "minecraft:iron_pickaxe": {
+      "wotr:earth": 1,
+      "wotr:metal": 1
+    },
+    "minecraft:iron_shovel": {
+      "wotr:earth": 1,
+      "wotr:metal": 1
+    },
+    "minecraft:iron_sword": {
+      "wotr:chaos": 1,
+      "wotr:metal": 1
+    },
+    "minecraft:iron_trapdoor": {
+      "wotr:metal": 1,
+      "wotr:order": 1
+    },
+    "minecraft:item_frame": {
+      "wotr:order": 1
+    },
+    "minecraft:jack_o_lantern": {
+      "wotr:light": 1,
+      "wotr:plant": 1
+    },
+    "minecraft:jukebox": {
+      "wotr:order": 1,
+      "wotr:power": 1
+    },
+    "minecraft:kelp": {
+      "wotr:plant": 1,
+      "wotr:water": 1
+    },
+    "minecraft:ladder": {
+      "wotr:plant": 1
+    },
+    "minecraft:lantern": {
+      "wotr:light": 1,
+      "wotr:metal": 1
+    },
+    "minecraft:lapis_block": {
+      "wotr:crystal": 1
+    },
+    "minecraft:lapis_lazuli": {
+      "wotr:crystal": 1
+    },
+    "minecraft:large_amethyst_bud": {
+      "wotr:crystal": 1
+    },
+    "minecraft:large_fern": {
+      "wotr:plant": 1
+    },
+    "minecraft:lava_bucket": {
+      "wotr:fire": 1
+    },
+    "minecraft:lead": {
+      "wotr:animal": 1,
+      "wotr:order": 1
+    },
+    "minecraft:leather": {
+      "wotr:animal": 1
+    },
+    "minecraft:leather_boots": {
+      "wotr:animal": 1
+    },
+    "minecraft:leather_chestplate": {
+      "wotr:animal": 1
+    },
+    "minecraft:leather_helmet": {
+      "wotr:animal": 1
+    },
+    "minecraft:leather_horse_armor": {
+      "wotr:animal": 1
+    },
+    "minecraft:leather_leggings": {
+      "wotr:animal": 1
+    },
+    "minecraft:lectern": {
+      "wotr:plant": 1
+    },
+    "minecraft:lever": {
+      "wotr:earth": 1,
+      "wotr:plant": 1
+    },
+    "minecraft:light_weighted_pressure_plate": {
+      "wotr:earth": 1
+    },
+    "minecraft:lightning_rod": {
+      "wotr:air": 1,
+      "wotr:metal": 1
+    },
+    "minecraft:lily_of_the_valley": {
+      "wotr:life": 1,
+      "wotr:plant": 1
+    },
+    "minecraft:lily_pad": {
+      "wotr:plant": 1,
+      "wotr:water": 1
+    },
+    "minecraft:lodestone": {
+      "wotr:space": 1
+    },
+    "minecraft:loom": {
+      "wotr:fabric": 1,
+      "wotr:order": 1
+    },
+    "minecraft:mace": {
+      "wotr:chaos": 1,
+      "wotr:metal": 1
+    },
+    "minecraft:magma_block": {
+      "wotr:earth": 1,
+      "wotr:fire": 1
+    },
+    "minecraft:magma_cream": {
+      "wotr:fire": 1,
+      "wotr:life": 1
+    },
+    "minecraft:mangrove_roots": {
+      "wotr:plant": 1
+    },
+    "minecraft:map": {
+      "wotr:knowledge": 1
+    },
+    "minecraft:medium_amethyst_bud": {
+      "wotr:crystal": 1
+    },
+    "minecraft:melon": {
+      "wotr:life": 1,
+      "wotr:plant": 1
+    },
+    "minecraft:melon_slice": {
+      "wotr:life": 1,
+      "wotr:plant": 1
+    },
+    "minecraft:milk_bucket": {
+      "wotr:animal": 1,
+      "wotr:water": 1
+    },
+    "minecraft:minecart": {
+      "wotr:order": 1
+    },
+    "minecraft:mojang_banner_pattern": {
+      "wotr:fabric": 1,
+      "wotr:knowledge": 1
+    },
+    "minecraft:moss_block": {
+      "wotr:plant": 1
+    },
+    "minecraft:moss_carpet": {
+      "wotr:plant": 1
+    },
+    "minecraft:mossy_cobblestone_slab": {
+      "wotr:earth": 1,
+      "wotr:plant": 1
+    },
+    "minecraft:mossy_cobblestone_stairs": {
+      "wotr:earth": 1,
+      "wotr:plant": 1
+    },
+    "minecraft:mossy_cobblestone_wall": {
+      "wotr:earth": 1,
+      "wotr:plant": 1
+    },
+    "minecraft:mossy_stone_brick_slab": {
+      "wotr:earth": 1,
+      "wotr:plant": 1
+    },
+    "minecraft:mossy_stone_brick_stairs": {
+      "wotr:earth": 1,
+      "wotr:plant": 1
+    },
+    "minecraft:mossy_stone_brick_wall": {
+      "wotr:earth": 1,
+      "wotr:plant": 1
+    },
+    "minecraft:mossy_stone_bricks": {
+      "wotr:earth": 1,
+      "wotr:plant": 1
+    },
+    "minecraft:mud": {
+      "wotr:earth": 1,
+      "wotr:water": 1
+    },
+    "minecraft:mud_brick_slab": {
+      "wotr:earth": 1
+    },
+    "minecraft:mud_brick_stairs": {
+      "wotr:earth": 1
+    },
+    "minecraft:mud_brick_wall": {
+      "wotr:earth": 1
+    },
+    "minecraft:mud_bricks": {
+      "wotr:earth": 1
+    },
+    "minecraft:muddy_mangrove_roots": {
+      "wotr:earth": 1,
+      "wotr:plant": 1
+    },
+    "minecraft:mushroom_stem": {
+      "wotr:life": 1
+    },
+    "minecraft:mushroom_stew": {
+      "wotr:life": 1
+    },
+    "minecraft:mycelium": {
+      "wotr:earth": 1,
+      "wotr:life": 1
+    },
+    "minecraft:name_tag": {
+      "wotr:order": 1
+    },
+    "minecraft:nautilus_shell": {
+      "wotr:animal": 1,
+      "wotr:water": 1
+    },
+    "minecraft:nether_brick_slab": {
+      "wotr:earth": 1,
+      "wotr:nether": 1
+    },
+    "minecraft:nether_brick_stairs": {
+      "wotr:earth": 1,
+      "wotr:nether": 1
+    },
+    "minecraft:nether_brick_wall": {
+      "wotr:earth": 1,
+      "wotr:nether": 1
+    },
+    "minecraft:nether_bricks": {
+      "wotr:earth": 1,
+      "wotr:nether": 1
+    },
+    "minecraft:nether_gold_ore": {
+      "wotr:metal": 1,
+      "wotr:nether": 1
+    },
+    "minecraft:nether_sprouts": {
+      "wotr:nether": 1,
+      "wotr:plant": 1
+    },
+    "minecraft:nether_star": {
+      "wotr:crystal": 1,
+      "wotr:nether": 1
+    },
+    "minecraft:nether_wart": {
+      "wotr:nether": 1,
+      "wotr:plant": 1
+    },
+    "minecraft:netherite_axe": {
+      "wotr:chaos": 1,
+      "wotr:metal": 1,
+      "wotr:nether": 1
+    },
+    "minecraft:netherite_block": {
+      "wotr:metal": 1,
+      "wotr:nether": 1
+    },
+    "minecraft:netherite_boots": {
+      "wotr:metal": 1,
+      "wotr:nether": 1
+    },
+    "minecraft:netherite_chestplate": {
+      "wotr:metal": 1,
+      "wotr:nether": 1
+    },
+    "minecraft:netherite_helmet": {
+      "wotr:metal": 1,
+      "wotr:nether": 1
+    },
+    "minecraft:netherite_hoe": {
+      "wotr:life": 1,
+      "wotr:metal": 1,
+      "wotr:nether": 1
+    },
+    "minecraft:netherite_leggings": {
+      "wotr:metal": 1,
+      "wotr:nether": 1
+    },
+    "minecraft:netherite_pickaxe": {
+      "wotr:earth": 1,
+      "wotr:metal": 1,
+      "wotr:nether": 1
+    },
+    "minecraft:netherite_scrap": {
+      "wotr:metal": 1,
+      "wotr:nether": 1
+    },
+    "minecraft:netherite_shovel": {
+      "wotr:earth": 1,
+      "wotr:metal": 1,
+      "wotr:nether": 1
+    },
+    "minecraft:netherite_sword": {
+      "wotr:chaos": 1,
+      "wotr:metal": 1,
+      "wotr:nether": 1
+    },
+    "minecraft:netherite_upgrade_smithing_template": {
+      "wotr:knowledge": 1
+    },
+    "minecraft:netherrack": {
+      "wotr:earth": 1,
+      "wotr:nether": 1
+    },
+    "minecraft:note_block": {
+      "wotr:order": 1,
+      "wotr:power": 1
+    },
+    "minecraft:observer": {
+      "wotr:power": 1
+    },
+    "minecraft:obsidian": {
+      "wotr:earth": 1,
+      "wotr:fire": 1
+    },
+    "minecraft:ochre_froglight": {
+      "wotr:life": 1,
+      "wotr:light": 1,
+      "wotr:water": 1
+    },
+    "minecraft:ominous_bottle": {
+      "wotr:chaos": 1,
+      "wotr:water": 1
+    },
+    "minecraft:ominous_trial_key": {
+      "wotr:chaos": 1
+    },
+    "minecraft:open_eyeblossom": {
+      "wotr:light": 1,
+      "wotr:plant": 1
+    },
+    "minecraft:orange_tulip": {
+      "wotr:life": 1,
+      "wotr:plant": 1
+    },
+    "minecraft:oxeye_daisy": {
+      "wotr:life": 1,
+      "wotr:plant": 1
+    },
+    "minecraft:oxidized_chiseled_copper": {
+      "wotr:metal": 1
+    },
+    "minecraft:oxidized_copper": {
+      "wotr:metal": 1
+    },
+    "minecraft:oxidized_copper_bulb": {
+      "wotr:light": 1,
+      "wotr:metal": 1
+    },
+    "minecraft:oxidized_copper_door": {
+      "wotr:metal": 1,
+      "wotr:order": 1
+    },
+    "minecraft:oxidized_copper_grate": {
+      "wotr:metal": 1,
+      "wotr:order": 1
+    },
+    "minecraft:oxidized_copper_trapdoor": {
+      "wotr:metal": 1,
+      "wotr:order": 1
+    },
+    "minecraft:oxidized_cut_copper": {
+      "wotr:metal": 1
+    },
+    "minecraft:oxidized_cut_copper_slab": {
+      "wotr:metal": 1
+    },
+    "minecraft:oxidized_cut_copper_stairs": {
+      "wotr:metal": 1
+    },
+    "minecraft:packed_ice": {
+      "wotr:water": 1
+    },
+    "minecraft:packed_mud": {
+      "wotr:earth": 1
+    },
+    "minecraft:painting": {
+      "wotr:order": 1
+    },
+    "minecraft:pale_hanging_moss": {
+      "wotr:plant": 1
+    },
+    "minecraft:pale_moss_block": {
+      "wotr:plant": 1
+    },
+    "minecraft:pale_moss_carpet": {
+      "wotr:plant": 1
+    },
+    "minecraft:pale_oak_fence_gate": {
+      "wotr:order": 1,
+      "wotr:plant": 1
+    },
+    "minecraft:paper": {
+      "wotr:knowledge": 1
+    },
+    "minecraft:pearlescent_froglight": {
+      "wotr:life": 1,
+      "wotr:light": 1,
+      "wotr:water": 1
+    },
+    "minecraft:phantom_membrane": {
+      "wotr:chaos": 1
+    },
+    "minecraft:piglin_banner_pattern": {
+      "wotr:fabric": 1,
+      "wotr:knowledge": 1
+    },
+    "minecraft:pink_petals": {
+      "wotr:plant": 1
+    },
+    "minecraft:pink_tulip": {
+      "wotr:life": 1,
+      "wotr:plant": 1
+    },
+    "minecraft:piston": {
+      "wotr:power": 1
+    },
+    "minecraft:podzol": {
+      "wotr:earth": 1,
+      "wotr:plant": 1
+    },
+    "minecraft:pointed_dripstone": {
+      "wotr:earth": 1
+    },
+    "minecraft:poisonous_potato": {
+      "wotr:life": 1,
+      "wotr:plant": 1
+    },
+    "minecraft:polished_andesite": {
+      "wotr:earth": 1
+    },
+    "minecraft:polished_andesite_slab": {
+      "wotr:earth": 1
+    },
+    "minecraft:polished_andesite_stairs": {
+      "wotr:earth": 1
+    },
+    "minecraft:polished_basalt": {
+      "wotr:earth": 1,
+      "wotr:fire": 1
+    },
+    "minecraft:polished_blackstone": {
+      "wotr:earth": 1
+    },
+    "minecraft:polished_blackstone_brick_slab": {
+      "wotr:earth": 1
+    },
+    "minecraft:polished_blackstone_brick_stairs": {
+      "wotr:earth": 1
+    },
+    "minecraft:polished_blackstone_brick_wall": {
+      "wotr:earth": 1
+    },
+    "minecraft:polished_blackstone_bricks": {
+      "wotr:earth": 1
+    },
+    "minecraft:polished_blackstone_pressure_plate": {
+      "wotr:earth": 1
+    },
+    "minecraft:polished_blackstone_slab": {
+      "wotr:earth": 1
+    },
+    "minecraft:polished_blackstone_stairs": {
+      "wotr:earth": 1
+    },
+    "minecraft:polished_blackstone_wall": {
+      "wotr:earth": 1
+    },
+    "minecraft:polished_deepslate": {
+      "wotr:earth": 1
+    },
+    "minecraft:polished_deepslate_slab": {
+      "wotr:earth": 1
+    },
+    "minecraft:polished_deepslate_stairs": {
+      "wotr:earth": 1
+    },
+    "minecraft:polished_deepslate_wall": {
+      "wotr:earth": 1
+    },
+    "minecraft:polished_diorite": {
+      "wotr:earth": 1
+    },
+    "minecraft:polished_diorite_slab": {
+      "wotr:earth": 1
+    },
+    "minecraft:polished_diorite_stairs": {
+      "wotr:earth": 1
+    },
+    "minecraft:polished_granite": {
+      "wotr:earth": 1
+    },
+    "minecraft:polished_granite_slab": {
+      "wotr:earth": 1
+    },
+    "minecraft:polished_granite_stairs": {
+      "wotr:earth": 1
+    },
+    "minecraft:polished_tuff": {
+      "wotr:earth": 1
+    },
+    "minecraft:polished_tuff_slab": {
+      "wotr:earth": 1
+    },
+    "minecraft:polished_tuff_stairs": {
+      "wotr:earth": 1
+    },
+    "minecraft:polished_tuff_wall": {
+      "wotr:earth": 1
+    },
+    "minecraft:popped_chorus_fruit": {
+      "wotr:end": 1,
+      "wotr:plant": 1
+    },
+    "minecraft:poppy": {
+      "wotr:life": 1,
+      "wotr:plant": 1
     },
     "minecraft:potato": {
+      "wotr:life": 1,
+      "wotr:plant": 1
+    },
+    "minecraft:powder_snow_bucket": {
+      "wotr:water": 1
+    },
+    "minecraft:powered_rail": {
+      "wotr:order": 1,
+      "wotr:power": 1
+    },
+    "minecraft:prismarine": {
+      "wotr:crystal": 1,
+      "wotr:water": 1
+    },
+    "minecraft:prismarine_brick_slab": {
+      "wotr:crystal": 1,
+      "wotr:order": 1,
+      "wotr:water": 1
+    },
+    "minecraft:prismarine_brick_stairs": {
+      "wotr:crystal": 1,
+      "wotr:order": 1,
+      "wotr:water": 1
+    },
+    "minecraft:prismarine_bricks": {
+      "wotr:crystal": 1,
+      "wotr:order": 1,
+      "wotr:water": 1
+    },
+    "minecraft:prismarine_crystals": {
+      "wotr:crystal": 1,
+      "wotr:water": 1
+    },
+    "minecraft:prismarine_shard": {
+      "wotr:crystal": 1,
+      "wotr:water": 1
+    },
+    "minecraft:prismarine_slab": {
+      "wotr:crystal": 1,
+      "wotr:water": 1
+    },
+    "minecraft:prismarine_stairs": {
+      "wotr:crystal": 1,
+      "wotr:order": 1,
+      "wotr:water": 1
+    },
+    "minecraft:prismarine_wall": {
+      "wotr:crystal": 1,
+      "wotr:order": 1,
+      "wotr:water": 1
+    },
+    "minecraft:pufferfish_bucket": {
+      "wotr:animal": 1,
+      "wotr:water": 1
+    },
+    "minecraft:pumpkin": {
+      "wotr:life": 1,
+      "wotr:plant": 1
+    },
+    "minecraft:pumpkin_pie": {
+      "wotr:life": 1,
+      "wotr:plant": 1
+    },
+    "minecraft:purpur_block": {
       "wotr:earth": 1,
-      "wotr:life": 2
+      "wotr:end": 1
+    },
+    "minecraft:purpur_pillar": {
+      "wotr:earth": 1,
+      "wotr:end": 1
+    },
+    "minecraft:purpur_slab": {
+      "wotr:earth": 1,
+      "wotr:end": 1
+    },
+    "minecraft:purpur_stairs": {
+      "wotr:earth": 1,
+      "wotr:end": 1
+    },
+    "minecraft:quartz": {
+      "wotr:crystal": 1,
+      "wotr:nether": 1
+    },
+    "minecraft:quartz_block": {
+      "wotr:crystal": 1,
+      "wotr:nether": 1
+    },
+    "minecraft:quartz_bricks": {
+      "wotr:crystal": 1,
+      "wotr:nether": 1
+    },
+    "minecraft:quartz_pillar": {
+      "wotr:crystal": 1,
+      "wotr:nether": 1
+    },
+    "minecraft:quartz_slab": {
+      "wotr:crystal": 1,
+      "wotr:nether": 1
+    },
+    "minecraft:quartz_stairs": {
+      "wotr:crystal": 1,
+      "wotr:nether": 1
+    },
+    "minecraft:rabbit_foot": {
+      "wotr:animal": 1,
+      "wotr:chaos": 1
+    },
+    "minecraft:rabbit_hide": {
+      "wotr:animal": 1
+    },
+    "minecraft:rabbit_stew": {
+      "wotr:animal": 1,
+      "wotr:life": 1
+    },
+    "minecraft:rail": {
+      "wotr:metal": 1,
+      "wotr:order": 1
+    },
+    "minecraft:raiser_armor_trim_smithing_template": {
+      "wotr:knowledge": 1
+    },
+    "minecraft:raw_copper": {
+      "wotr:metal": 1
+    },
+    "minecraft:raw_copper_block": {
+      "wotr:metal": 1
+    },
+    "minecraft:raw_gold": {
+      "wotr:metal": 1
+    },
+    "minecraft:raw_gold_block": {
+      "wotr:metal": 1
+    },
+    "minecraft:raw_iron": {
+      "wotr:metal": 1
+    },
+    "minecraft:raw_iron_block": {
+      "wotr:metal": 1
+    },
+    "minecraft:recovery_compass": {
+      "wotr:death": 1,
+      "wotr:space": 1
+    },
+    "minecraft:red_mushroom_block": {
+      "wotr:life": 1
+    },
+    "minecraft:red_nether_brick_slab": {
+      "wotr:earth": 1,
+      "wotr:nether": 1
+    },
+    "minecraft:red_nether_brick_stairs": {
+      "wotr:earth": 1,
+      "wotr:nether": 1
+    },
+    "minecraft:red_nether_brick_wall": {
+      "wotr:earth": 1,
+      "wotr:nether": 1
+    },
+    "minecraft:red_nether_bricks": {
+      "wotr:earth": 1,
+      "wotr:nether": 1
+    },
+    "minecraft:red_sandstone_wall": {
+      "wotr:earth": 1
+    },
+    "minecraft:red_tulip": {
+      "wotr:life": 1,
+      "wotr:plant": 1
+    },
+    "minecraft:redstone": {
+      "wotr:power": 1
+    },
+    "minecraft:redstone_block": {
+      "wotr:power": 1
+    },
+    "minecraft:redstone_lamp": {
+      "wotr:light": 1,
+      "wotr:power": 1
+    },
+    "minecraft:redstone_torch": {
+      "wotr:light": 1,
+      "wotr:power": 1
+    },
+    "minecraft:repeater": {
+      "wotr:power": 1
+    },
+    "minecraft:resin_block": {
+      "wotr:crystal": 1,
+      "wotr:plant": 1
+    },
+    "minecraft:resin_brick": {
+      "wotr:crystal": 1,
+      "wotr:plant": 1
+    },
+    "minecraft:resin_brick_slab": {
+      "wotr:crystal": 1,
+      "wotr:plant": 1
+    },
+    "minecraft:resin_brick_stairs": {
+      "wotr:crystal": 1,
+      "wotr:plant": 1
+    },
+    "minecraft:resin_brick_wall": {
+      "wotr:crystal": 1,
+      "wotr:plant": 1
+    },
+    "minecraft:resin_bricks": {
+      "wotr:crystal": 1,
+      "wotr:plant": 1
+    },
+    "minecraft:resin_clump": {
+      "wotr:crystal": 1,
+      "wotr:plant": 1
+    },
+    "minecraft:respawn_anchor": {
+      "wotr:death": 1,
+      "wotr:nether": 1
+    },
+    "minecraft:rib_armor_trim_smithing_template": {
+      "wotr:knowledge": 1
+    },
+    "minecraft:rooted_dirt": {
+      "wotr:earth": 1,
+      "wotr:plant": 1
+    },
+    "minecraft:rotten_flesh": {
+      "wotr:animal": 1,
+      "wotr:death": 1
+    },
+    "minecraft:saddle": {
+      "wotr:animal": 1
+    },
+    "minecraft:salmon_bucket": {
+      "wotr:animal": 1,
+      "wotr:water": 1
+    },
+    "minecraft:sandstone_wall": {
+      "wotr:earth": 1
+    },
+    "minecraft:scaffolding": {
+      "wotr:plant": 1
+    },
+    "minecraft:sculk": {
+      "wotr:dark": 1,
+      "wotr:life": 1
+    },
+    "minecraft:sculk_catalyst": {
+      "wotr:dark": 1,
+      "wotr:life": 1
+    },
+    "minecraft:sculk_sensor": {
+      "wotr:dark": 1,
+      "wotr:life": 1
+    },
+    "minecraft:sculk_shrieker": {
+      "wotr:dark": 1,
+      "wotr:life": 1
+    },
+    "minecraft:sculk_vein": {
+      "wotr:dark": 1,
+      "wotr:life": 1
+    },
+    "minecraft:sea_lantern": {
+      "wotr:light": 1,
+      "wotr:water": 1
+    },
+    "minecraft:sea_pickle": {
+      "wotr:plant": 1,
+      "wotr:water": 1
+    },
+    "minecraft:seagrass": {
+      "wotr:plant": 1,
+      "wotr:water": 1
+    },
+    "minecraft:sentry_armor_trim_smithing_template": {
+      "wotr:knowledge": 1
+    },
+    "minecraft:shaper_armor_trim_smithing_template": {
+      "wotr:knowledge": 1
+    },
+    "minecraft:shears": {
+      "wotr:metal": 1,
+      "wotr:order": 1
+    },
+    "minecraft:short_grass": {
+      "wotr:plant": 1
+    },
+    "minecraft:shroomlight": {
+      "wotr:life": 1,
+      "wotr:light": 1
+    },
+    "minecraft:shulker_shell": {
+      "wotr:animal": 1,
+      "wotr:end": 1
+    },
+    "minecraft:silence_armor_trim_smithing_template": {
+      "wotr:knowledge": 1
+    },
+    "minecraft:skull_banner_pattern": {
+      "wotr:fabric": 1,
+      "wotr:knowledge": 1
+    },
+    "minecraft:slime_ball": {
+      "wotr:animal": 1,
+      "wotr:water": 1
+    },
+    "minecraft:slime_block": {
+      "wotr:animal": 1,
+      "wotr:water": 1
+    },
+    "minecraft:small_amethyst_bud": {
+      "wotr:crystal": 1
+    },
+    "minecraft:small_dripleaf": {
+      "wotr:plant": 1
+    },
+    "minecraft:smithing_table": {
+      "wotr:metal": 1,
+      "wotr:order": 1
+    },
+    "minecraft:smoker": {
+      "wotr:fire": 1
+    },
+    "minecraft:smooth_basalt": {
+      "wotr:earth": 1,
+      "wotr:fire": 1
+    },
+    "minecraft:smooth_quartz": {
+      "wotr:crystal": 1,
+      "wotr:nether": 1
+    },
+    "minecraft:smooth_quartz_slab": {
+      "wotr:crystal": 1,
+      "wotr:nether": 1
+    },
+    "minecraft:smooth_quartz_stairs": {
+      "wotr:crystal": 1,
+      "wotr:nether": 1
+    },
+    "minecraft:smooth_stone": {
+      "wotr:earth": 1
+    },
+    "minecraft:smooth_stone_slab": {
+      "wotr:earth": 1
+    },
+    "minecraft:sniffer_egg": {
+      "wotr:animal": 1,
+      "wotr:life": 1
+    },
+    "minecraft:snout_armor_trim_smithing_template": {
+      "wotr:knowledge": 1
+    },
+    "minecraft:snow": {
+      "wotr:water": 1
+    },
+    "minecraft:snow_block": {
+      "wotr:water": 1
+    },
+    "minecraft:snowball": {
+      "wotr:water": 1
+    },
+    "minecraft:soul_campfire": {
+      "wotr:light": 1,
+      "wotr:nether": 1
+    },
+    "minecraft:soul_lantern": {
+      "wotr:light": 1,
+      "wotr:nether": 1
+    },
+    "minecraft:soul_sand": {
+      "wotr:earth": 1,
+      "wotr:nether": 1
+    },
+    "minecraft:soul_soil": {
+      "wotr:earth": 1,
+      "wotr:nether": 1
+    },
+    "minecraft:soul_torch": {
+      "wotr:light": 1,
+      "wotr:nether": 1
+    },
+    "minecraft:spectral_arrow": {
+      "wotr:chaos": 1,
+      "wotr:death": 1
+    },
+    "minecraft:spider_eye": {
+      "wotr:animal": 1
+    },
+    "minecraft:spire_armor_trim_smithing_template": {
+      "wotr:knowledge": 1
+    },
+    "minecraft:sponge": {
+      "wotr:water": 1
+    },
+    "minecraft:spore_blossom": {
+      "wotr:life": 1,
+      "wotr:plant": 1
+    },
+    "minecraft:spyglass": {
+      "wotr:space": 1
+    },
+    "minecraft:stick": {
+      "wotr:plant": 1
+    },
+    "minecraft:sticky_piston": {
+      "wotr:power": 1
+    },
+    "minecraft:stone_axe": {
+      "wotr:chaos": 1,
+      "wotr:earth": 1
+    },
+    "minecraft:stone_brick_slab": {
+      "wotr:earth": 1
+    },
+    "minecraft:stone_brick_stairs": {
+      "wotr:earth": 1
+    },
+    "minecraft:stone_brick_wall": {
+      "wotr:earth": 1
+    },
+    "minecraft:stone_hoe": {
+      "wotr:earth": 1,
+      "wotr:life": 1
+    },
+    "minecraft:stone_pickaxe": {
+      "wotr:earth": 1
+    },
+    "minecraft:stone_pressure_plate": {
+      "wotr:earth": 1
+    },
+    "minecraft:stone_shovel": {
+      "wotr:earth": 1
+    },
+    "minecraft:stone_slab": {
+      "wotr:earth": 1
+    },
+    "minecraft:stone_stairs": {
+      "wotr:earth": 1
+    },
+    "minecraft:stone_sword": {
+      "wotr:chaos": 1,
+      "wotr:earth": 1
+    },
+    "minecraft:stonecutter": {
+      "wotr:earth": 1,
+      "wotr:order": 1
+    },
+    "minecraft:string": {
+      "wotr:fabric": 1
+    },
+    "minecraft:sugar": {
+      "wotr:life": 1
+    },
+    "minecraft:sugar_cane": {
+      "wotr:life": 1,
+      "wotr:plant": 1
+    },
+    "minecraft:suspicious_gravel": {
+      "wotr:earth": 1
+    },
+    "minecraft:suspicious_stew": {
+      "wotr:chaos": 1
+    },
+    "minecraft:sweet_berries": {
+      "wotr:life": 1,
+      "wotr:plant": 1
+    },
+    "minecraft:tadpole_bucket": {
+      "wotr:animal": 1,
+      "wotr:water": 1
+    },
+    "minecraft:tall_grass": {
+      "wotr:plant": 1
+    },
+    "minecraft:target": {
+      "wotr:plant": 1
+    },
+    "minecraft:tide_armor_trim_smithing_template": {
+      "wotr:knowledge": 1
+    },
+    "minecraft:tinted_glass": {
+      "wotr:crystal": 1,
+      "wotr:earth": 1
+    },
+    "minecraft:tipped_arrow": {
+      "wotr:chaos": 1
+    },
+    "minecraft:tnt": {
+      "wotr:fire": 1
+    },
+    "minecraft:tnt_minecart": {
+      "wotr:fire": 1,
+      "wotr:order": 1
+    },
+    "minecraft:torch": {
+      "wotr:fire": 1,
+      "wotr:light": 1
+    },
+    "minecraft:torchflower": {
+      "wotr:life": 1,
+      "wotr:plant": 1
+    },
+    "minecraft:totem_of_undying": {
+      "wotr:death": 1,
+      "wotr:life": 1
+    },
+    "minecraft:trial_key": {
+      "wotr:chaos": 1
+    },
+    "minecraft:trident": {
+      "wotr:chaos": 1,
+      "wotr:water": 1
+    },
+    "minecraft:tripwire_hook": {
+      "wotr:metal": 1,
+      "wotr:plant": 1
+    },
+    "minecraft:tropical_fish_bucket": {
+      "wotr:animal": 1,
+      "wotr:water": 1
+    },
+    "minecraft:tube_coral": {
+      "wotr:plant": 1,
+      "wotr:water": 1
+    },
+    "minecraft:tube_coral_block": {
+      "wotr:plant": 1,
+      "wotr:water": 1
+    },
+    "minecraft:tube_coral_fan": {
+      "wotr:plant": 1,
+      "wotr:water": 1
+    },
+    "minecraft:tuff_brick_slab": {
+      "wotr:earth": 1
+    },
+    "minecraft:tuff_brick_stairs": {
+      "wotr:earth": 1
+    },
+    "minecraft:tuff_brick_wall": {
+      "wotr:earth": 1
+    },
+    "minecraft:tuff_bricks": {
+      "wotr:earth": 1
+    },
+    "minecraft:tuff_slab": {
+      "wotr:earth": 1
+    },
+    "minecraft:tuff_stairs": {
+      "wotr:earth": 1
+    },
+    "minecraft:tuff_wall": {
+      "wotr:earth": 1
+    },
+    "minecraft:turtle_egg": {
+      "wotr:animal": 1,
+      "wotr:life": 1
+    },
+    "minecraft:turtle_helmet": {
+      "wotr:water": 1
+    },
+    "minecraft:turtle_scute": {
+      "wotr:animal": 1,
+      "wotr:water": 1
+    },
+    "minecraft:twisting_vines": {
+      "wotr:nether": 1,
+      "wotr:plant": 1
+    },
+    "minecraft:verdant_froglight": {
+      "wotr:life": 1,
+      "wotr:light": 1,
+      "wotr:water": 1
+    },
+    "minecraft:vex_armor_trim_smithing_template": {
+      "wotr:knowledge": 1
+    },
+    "minecraft:vine": {
+      "wotr:plant": 1
+    },
+    "minecraft:ward_armor_trim_smithing_template": {
+      "wotr:knowledge": 1
+    },
+    "minecraft:warped_fungus": {
+      "wotr:life": 1,
+      "wotr:nether": 1
+    },
+    "minecraft:warped_fungus_on_a_stick": {
+      "wotr:nether": 1,
+      "wotr:plant": 1
+    },
+    "minecraft:warped_nylium": {
+      "wotr:earth": 1,
+      "wotr:nether": 1
+    },
+    "minecraft:warped_roots": {
+      "wotr:nether": 1,
+      "wotr:plant": 1
+    },
+    "minecraft:water_bucket": {
+      "wotr:water": 1
+    },
+    "minecraft:waxed_chiseled_copper": {
+      "wotr:metal": 1
+    },
+    "minecraft:waxed_copper_block": {
+      "wotr:metal": 1
+    },
+    "minecraft:waxed_copper_bulb": {
+      "wotr:light": 1,
+      "wotr:metal": 1
+    },
+    "minecraft:waxed_copper_door": {
+      "wotr:metal": 1,
+      "wotr:order": 1
+    },
+    "minecraft:waxed_copper_grate": {
+      "wotr:metal": 1,
+      "wotr:order": 1
+    },
+    "minecraft:waxed_copper_trapdoor": {
+      "wotr:metal": 1,
+      "wotr:order": 1
+    },
+    "minecraft:waxed_cut_copper": {
+      "wotr:metal": 1
+    },
+    "minecraft:waxed_cut_copper_slab": {
+      "wotr:metal": 1
+    },
+    "minecraft:waxed_cut_copper_stairs": {
+      "wotr:metal": 1
+    },
+    "minecraft:waxed_exposed_chiseled_copper": {
+      "wotr:metal": 1
+    },
+    "minecraft:waxed_exposed_copper": {
+      "wotr:metal": 1
+    },
+    "minecraft:waxed_exposed_copper_bulb": {
+      "wotr:light": 1,
+      "wotr:metal": 1
+    },
+    "minecraft:waxed_exposed_copper_door": {
+      "wotr:metal": 1,
+      "wotr:order": 1
+    },
+    "minecraft:waxed_exposed_copper_grate": {
+      "wotr:metal": 1,
+      "wotr:order": 1
+    },
+    "minecraft:waxed_exposed_copper_trapdoor": {
+      "wotr:metal": 1,
+      "wotr:order": 1
+    },
+    "minecraft:waxed_exposed_cut_copper": {
+      "wotr:metal": 1
+    },
+    "minecraft:waxed_exposed_cut_copper_slab": {
+      "wotr:metal": 1
+    },
+    "minecraft:waxed_exposed_cut_copper_stairs": {
+      "wotr:metal": 1
+    },
+    "minecraft:waxed_oxidized_chiseled_copper": {
+      "wotr:metal": 1
+    },
+    "minecraft:waxed_oxidized_copper": {
+      "wotr:metal": 1
+    },
+    "minecraft:waxed_oxidized_copper_bulb": {
+      "wotr:light": 1,
+      "wotr:metal": 1
+    },
+    "minecraft:waxed_oxidized_copper_door": {
+      "wotr:metal": 1,
+      "wotr:order": 1
+    },
+    "minecraft:waxed_oxidized_copper_grate": {
+      "wotr:metal": 1,
+      "wotr:order": 1
+    },
+    "minecraft:waxed_oxidized_copper_trapdoor": {
+      "wotr:metal": 1,
+      "wotr:order": 1
+    },
+    "minecraft:waxed_oxidized_cut_copper": {
+      "wotr:metal": 1
+    },
+    "minecraft:waxed_oxidized_cut_copper_slab": {
+      "wotr:metal": 1
+    },
+    "minecraft:waxed_oxidized_cut_copper_stairs": {
+      "wotr:metal": 1
+    },
+    "minecraft:waxed_weathered_chiseled_copper": {
+      "wotr:metal": 1
+    },
+    "minecraft:waxed_weathered_copper": {
+      "wotr:metal": 1
+    },
+    "minecraft:waxed_weathered_copper_bulb": {
+      "wotr:light": 1,
+      "wotr:metal": 1
+    },
+    "minecraft:waxed_weathered_copper_door": {
+      "wotr:metal": 1,
+      "wotr:order": 1
+    },
+    "minecraft:waxed_weathered_copper_grate": {
+      "wotr:metal": 1,
+      "wotr:order": 1
+    },
+    "minecraft:waxed_weathered_copper_trapdoor": {
+      "wotr:metal": 1,
+      "wotr:order": 1
+    },
+    "minecraft:waxed_weathered_cut_copper": {
+      "wotr:metal": 1
+    },
+    "minecraft:waxed_weathered_cut_copper_slab": {
+      "wotr:metal": 1
+    },
+    "minecraft:waxed_weathered_cut_copper_stairs": {
+      "wotr:metal": 1
+    },
+    "minecraft:wayfinder_armor_trim_smithing_template": {
+      "wotr:knowledge": 1
+    },
+    "minecraft:weathered_chiseled_copper": {
+      "wotr:metal": 1
+    },
+    "minecraft:weathered_copper": {
+      "wotr:metal": 1
+    },
+    "minecraft:weathered_copper_bulb": {
+      "wotr:light": 1,
+      "wotr:metal": 1
+    },
+    "minecraft:weathered_copper_door": {
+      "wotr:metal": 1,
+      "wotr:order": 1
+    },
+    "minecraft:weathered_copper_grate": {
+      "wotr:metal": 1,
+      "wotr:order": 1
+    },
+    "minecraft:weathered_copper_trapdoor": {
+      "wotr:metal": 1,
+      "wotr:order": 1
+    },
+    "minecraft:weathered_cut_copper": {
+      "wotr:metal": 1
+    },
+    "minecraft:weathered_cut_copper_slab": {
+      "wotr:metal": 1
+    },
+    "minecraft:weathered_cut_copper_stairs": {
+      "wotr:metal": 1
+    },
+    "minecraft:weeping_vines": {
+      "wotr:nether": 1,
+      "wotr:plant": 1
+    },
+    "minecraft:wet_sponge": {
+      "wotr:water": 1
+    },
+    "minecraft:wheat": {
+      "wotr:life": 1,
+      "wotr:plant": 1
+    },
+    "minecraft:white_tulip": {
+      "wotr:life": 1,
+      "wotr:plant": 1
+    },
+    "minecraft:wild_armor_trim_smithing_template": {
+      "wotr:knowledge": 1
+    },
+    "minecraft:wind_charge": {
+      "wotr:air": 1
+    },
+    "minecraft:wither_rose": {
+      "wotr:death": 1,
+      "wotr:plant": 1
+    },
+    "minecraft:wolf_armor": {
+      "wotr:animal": 1
+    },
+    "minecraft:wooden_axe": {
+      "wotr:chaos": 1,
+      "wotr:plant": 1
+    },
+    "minecraft:wooden_hoe": {
+      "wotr:life": 1,
+      "wotr:plant": 1
+    },
+    "minecraft:wooden_pickaxe": {
+      "wotr:earth": 1,
+      "wotr:plant": 1
+    },
+    "minecraft:wooden_shovel": {
+      "wotr:earth": 1,
+      "wotr:plant": 1
+    },
+    "minecraft:wooden_sword": {
+      "wotr:chaos": 1,
+      "wotr:plant": 1
+    },
+    "minecraft:writable_book": {
+      "wotr:knowledge": 1
+    },
+    "minecraft:written_book": {
+      "wotr:knowledge": 1
     }
   }
 }

--- a/src/main/java/com/wanderersoftherift/wotr/WanderersOfTheRift.java
+++ b/src/main/java/com/wanderersoftherift/wotr/WanderersOfTheRift.java
@@ -3,6 +3,7 @@ package com.wanderersoftherift.wotr;
 import com.mojang.logging.LogUtils;
 import com.wanderersoftherift.wotr.commands.AbilityCommands;
 import com.wanderersoftherift.wotr.commands.DebugCommands;
+import com.wanderersoftherift.wotr.commands.EssenceCommands;
 import com.wanderersoftherift.wotr.commands.InventorySnapshotCommands;
 import com.wanderersoftherift.wotr.commands.RiftKeyCommands;
 import com.wanderersoftherift.wotr.commands.RiftMapCommands;
@@ -158,6 +159,7 @@ public class WanderersOfTheRift {
         new DebugCommands().registerCommand(event.getDispatcher(), event.getBuildContext());
         AbilityCommands.register(event.getDispatcher(), event.getBuildContext());
         new RiftKeyCommands().registerCommand(event.getDispatcher(), event.getBuildContext());
+        new EssenceCommands().registerCommand(event.getDispatcher(), event.getBuildContext());
     }
 
     @SubscribeEvent

--- a/src/main/java/com/wanderersoftherift/wotr/commands/EssenceCommands.java
+++ b/src/main/java/com/wanderersoftherift/wotr/commands/EssenceCommands.java
@@ -50,7 +50,13 @@ public class EssenceCommands extends BaseCommand {
 
     private int dumpSpecified(CommandContext<CommandSourceStack> cmd) {
         Registry<Item> registry = cmd.getSource().getServer().registryAccess().lookupOrThrow(Registries.ITEM);
-        List<ResourceLocation> types = registry.stream().map(Item::builtInRegistryHolder).map(x -> x.getData(ModDataMaps.ESSENCE_VALUE_DATA)).filter(Objects::nonNull).flatMap(x -> x.values().keySet().stream()).distinct().toList();
+        List<ResourceLocation> types = registry.stream()
+                .map(Item::builtInRegistryHolder)
+                .map(x -> x.getData(ModDataMaps.ESSENCE_VALUE_DATA))
+                .filter(Objects::nonNull)
+                .flatMap(x -> x.values().keySet().stream())
+                .distinct()
+                .toList();
 
         Joiner itemJoiner = Joiner.on("\",\"");
 
@@ -58,7 +64,6 @@ public class EssenceCommands extends BaseCommand {
             writer.write("\"item\",\"");
             writer.write(itemJoiner.join(types.stream().map(ResourceLocation::toString).toList()));
             writer.write("\"\n");
-
 
             List<Holder.Reference<Item>> items = registry.stream().map(Item::builtInRegistryHolder).toList();
             for (var item : items) {

--- a/src/main/java/com/wanderersoftherift/wotr/commands/EssenceCommands.java
+++ b/src/main/java/com/wanderersoftherift/wotr/commands/EssenceCommands.java
@@ -1,0 +1,83 @@
+package com.wanderersoftherift.wotr.commands;
+
+import com.google.common.base.Joiner;
+import com.google.gson.Gson;
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import com.mojang.brigadier.context.CommandContext;
+import com.wanderersoftherift.wotr.init.ModDataMaps;
+import com.wanderersoftherift.wotr.item.essence.EssenceValue;
+import net.minecraft.commands.CommandBuildContext;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
+import net.minecraft.core.Holder;
+import net.minecraft.core.Registry;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.Item;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Objects;
+
+public class EssenceCommands extends BaseCommand {
+    public EssenceCommands() {
+        super("essence", Commands.LEVEL_OWNERS);
+    }
+
+    @Override
+    protected void buildCommand(LiteralArgumentBuilder<CommandSourceStack> builder, CommandBuildContext context) {
+        builder.then(Commands.literal("dumpEssencelessItems").executes(this::dumpUnspecified))
+                .then(Commands.literal("dumpEssenceValues").executes(this::dumpSpecified));
+    }
+
+    private int dumpUnspecified(CommandContext<CommandSourceStack> cmd) {
+        Registry<Item> registry = cmd.getSource().getServer().registryAccess().lookupOrThrow(Registries.ITEM);
+        try (BufferedWriter writer = Files.newBufferedWriter(Paths.get("missingessence.json"))) {
+            Gson gson = new Gson();
+            gson.toJson(registry.stream()
+                    .map(Item::builtInRegistryHolder)
+                    .filter(x -> x.getData(ModDataMaps.ESSENCE_VALUE_DATA) == null)
+                    .map(Holder::getRegisteredName)
+                    .toList(), writer);
+        } catch (IOException e) {
+            return 1;
+        }
+        return 0;
+    }
+
+    private int dumpSpecified(CommandContext<CommandSourceStack> cmd) {
+        Registry<Item> registry = cmd.getSource().getServer().registryAccess().lookupOrThrow(Registries.ITEM);
+        List<ResourceLocation> types = registry.stream().map(Item::builtInRegistryHolder).map(x -> x.getData(ModDataMaps.ESSENCE_VALUE_DATA)).filter(Objects::nonNull).flatMap(x -> x.values().keySet().stream()).distinct().toList();
+
+        Joiner itemJoiner = Joiner.on("\",\"");
+
+        try (BufferedWriter writer = Files.newBufferedWriter(Paths.get("essence.csv"))) {
+            writer.write("\"item\",\"");
+            writer.write(itemJoiner.join(types.stream().map(ResourceLocation::toString).toList()));
+            writer.write("\"\n");
+
+
+            List<Holder.Reference<Item>> items = registry.stream().map(Item::builtInRegistryHolder).toList();
+            for (var item : items) {
+                EssenceValue data = item.getData(ModDataMaps.ESSENCE_VALUE_DATA);
+                if (data == null) {
+                    continue;
+                }
+                writer.write("\"");
+                writer.write(item.getRegisteredName());
+                writer.write("\"");
+                for (ResourceLocation type : types) {
+                    writer.write(",");
+                    writer.write(Integer.toString(data.values().getOrDefault(type, 0)));
+                }
+                writer.write("\n");
+            }
+        } catch (IOException e) {
+            return 1;
+        }
+        return 0;
+    }
+}

--- a/src/main/java/com/wanderersoftherift/wotr/datagen/ModDataMapProvider.java
+++ b/src/main/java/com/wanderersoftherift/wotr/datagen/ModDataMapProvider.java
@@ -144,10 +144,7 @@ public class ModDataMapProvider extends DataMapProvider {
                 .add(Items.WHEAT.builtInRegistryHolder(), new EssenceValue(plant, 1, life, 1), false)
                 .add(Items.HAY_BLOCK.builtInRegistryHolder(), new EssenceValue(plant, 1, life, 1), false)
                 .add(Items.SWEET_BERRIES.builtInRegistryHolder(), new EssenceValue(plant, 1, life, 1), false)
-                .add(Items.GLOW_BERRIES.builtInRegistryHolder(), new EssenceValue(plant, 1, light, 1), false);
-
-        // Seeds
-        this.builder(ModDataMaps.ESSENCE_VALUE_DATA)
+                .add(Items.GLOW_BERRIES.builtInRegistryHolder(), new EssenceValue(plant, 1, light, 1), false)
                 .add(Tags.Items.SEEDS, new EssenceValue(plant, 1, life, 1), false);
 
         // Fungi
@@ -198,7 +195,8 @@ public class ModDataMapProvider extends DataMapProvider {
                 .add(Items.RESIN_BRICK_SLAB.builtInRegistryHolder(), new EssenceValue(plant, 1, crystal, 1), false)
                 .add(Items.RESIN_BRICK_STAIRS.builtInRegistryHolder(), new EssenceValue(plant, 1, crystal, 1), false)
                 .add(Items.RESIN_BRICK_WALL.builtInRegistryHolder(), new EssenceValue(plant, 1, crystal, 1), false)
-                .add(Items.CHISELED_RESIN_BRICKS.builtInRegistryHolder(), new EssenceValue(plant, 1, crystal, 1), false);
+                .add(Items.CHISELED_RESIN_BRICKS.builtInRegistryHolder(), new EssenceValue(plant, 1, crystal, 1),
+                        false);
 
         // End flora
         this.builder(ModDataMaps.ESSENCE_VALUE_DATA)
@@ -214,7 +212,8 @@ public class ModDataMapProvider extends DataMapProvider {
                 .add(Items.SCULK_SENSOR.builtInRegistryHolder(), new EssenceValue(dark, 1, life, 1), false)
                 .add(Items.SCULK_VEIN.builtInRegistryHolder(), new EssenceValue(dark, 1, life, 1), false)
                 .add(Items.SCULK_SHRIEKER.builtInRegistryHolder(), new EssenceValue(dark, 1, life, 1), false)
-                .add(Items.CALIBRATED_SCULK_SENSOR.builtInRegistryHolder(), new EssenceValue(dark, 1, crystal, 1), false);
+                .add(Items.CALIBRATED_SCULK_SENSOR.builtInRegistryHolder(), new EssenceValue(dark, 1, crystal, 1),
+                        false);
 
         // Water life
         this.builder(ModDataMaps.ESSENCE_VALUE_DATA)
@@ -225,7 +224,6 @@ public class ModDataMapProvider extends DataMapProvider {
                 .add(Items.AXOLOTL_BUCKET.builtInRegistryHolder(), new EssenceValue(water, 1, animal, 1), false)
                 .add(Items.TADPOLE_BUCKET.builtInRegistryHolder(), new EssenceValue(water, 1, animal, 1), false)
                 .add(Items.NAUTILUS_SHELL.builtInRegistryHolder(), new EssenceValue(water, 1, animal, 1), false)
-
 
                 .add(Items.SPONGE.builtInRegistryHolder(), new EssenceValue(water, 1), false)
                 .add(Items.WET_SPONGE.builtInRegistryHolder(), new EssenceValue(water, 1), false)
@@ -313,8 +311,7 @@ public class ModDataMapProvider extends DataMapProvider {
                 .add(Items.FERMENTED_SPIDER_EYE.builtInRegistryHolder(), new EssenceValue(animal, 1), false)
                 .add(Items.BAKED_POTATO.builtInRegistryHolder(), new EssenceValue(plant, 1, life, 1), false)
                 .add(Items.RABBIT_STEW.builtInRegistryHolder(), new EssenceValue(animal, 1, life, 1), false)
-                .add(Items.BEETROOT_SOUP.builtInRegistryHolder(), new EssenceValue(plant, 1, life, 1), false)
-        ;
+                .add(Items.BEETROOT_SOUP.builtInRegistryHolder(), new EssenceValue(plant, 1, life, 1), false);
 
         // Eggs
         this.builder(ModDataMaps.ESSENCE_VALUE_DATA)
@@ -340,8 +337,7 @@ public class ModDataMapProvider extends DataMapProvider {
                 .add(Items.ENDER_PEARL.builtInRegistryHolder(), new EssenceValue(end, 1, space, 1), false)
                 .add(Items.ENDER_EYE.builtInRegistryHolder(), new EssenceValue(space, 1, knowledge, 1), false)
                 .add(Items.MAGMA_CREAM.builtInRegistryHolder(), new EssenceValue(life, 1, fire, 1), false)
-                .add(Items.SHULKER_SHELL.builtInRegistryHolder(), new EssenceValue(animal, 1, end, 1), false)
-        ;
+                .add(Items.SHULKER_SHELL.builtInRegistryHolder(), new EssenceValue(animal, 1, end, 1), false);
 
         // Bones
         this.builder(ModDataMaps.ESSENCE_VALUE_DATA)
@@ -357,17 +353,26 @@ public class ModDataMapProvider extends DataMapProvider {
                 .add(ItemTags.BANNERS, new EssenceValue(fabric, 1, order, 1), false)
                 .add(ItemTags.BEDS, new EssenceValue(fabric, 1, order, 1), false)
                 .add(Tags.Items.DYES, new EssenceValue(order, 1, water, 1), false)
-                .add(Items.FLOWER_BANNER_PATTERN.builtInRegistryHolder(), new EssenceValue(fabric, 1, knowledge, 1), false)
-                .add(Items.CREEPER_BANNER_PATTERN.builtInRegistryHolder(), new EssenceValue(fabric, 1, knowledge, 1), false)
-                .add(Items.SKULL_BANNER_PATTERN.builtInRegistryHolder(), new EssenceValue(fabric, 1, knowledge, 1), false)
-                .add(Items.MOJANG_BANNER_PATTERN.builtInRegistryHolder(), new EssenceValue(fabric, 1, knowledge, 1), false)
-                .add(Items.GLOBE_BANNER_PATTERN.builtInRegistryHolder(), new EssenceValue(fabric, 1, knowledge, 1), false)
-                .add(Items.PIGLIN_BANNER_PATTERN.builtInRegistryHolder(), new EssenceValue(fabric, 1, knowledge, 1), false)
-                .add(Items.FLOW_BANNER_PATTERN.builtInRegistryHolder(), new EssenceValue(fabric, 1, knowledge, 1), false)
-                .add(Items.GUSTER_BANNER_PATTERN.builtInRegistryHolder(), new EssenceValue(fabric, 1, knowledge, 1), false)
-                .add(Items.FIELD_MASONED_BANNER_PATTERN.builtInRegistryHolder(), new EssenceValue(fabric, 1, knowledge, 1), false)
-                .add(Items.BORDURE_INDENTED_BANNER_PATTERN.builtInRegistryHolder(), new EssenceValue(fabric, 1, knowledge, 1), false)
-        ;
+                .add(Items.FLOWER_BANNER_PATTERN.builtInRegistryHolder(), new EssenceValue(fabric, 1, knowledge, 1),
+                        false)
+                .add(Items.CREEPER_BANNER_PATTERN.builtInRegistryHolder(), new EssenceValue(fabric, 1, knowledge, 1),
+                        false)
+                .add(Items.SKULL_BANNER_PATTERN.builtInRegistryHolder(), new EssenceValue(fabric, 1, knowledge, 1),
+                        false)
+                .add(Items.MOJANG_BANNER_PATTERN.builtInRegistryHolder(), new EssenceValue(fabric, 1, knowledge, 1),
+                        false)
+                .add(Items.GLOBE_BANNER_PATTERN.builtInRegistryHolder(), new EssenceValue(fabric, 1, knowledge, 1),
+                        false)
+                .add(Items.PIGLIN_BANNER_PATTERN.builtInRegistryHolder(), new EssenceValue(fabric, 1, knowledge, 1),
+                        false)
+                .add(Items.FLOW_BANNER_PATTERN.builtInRegistryHolder(), new EssenceValue(fabric, 1, knowledge, 1),
+                        false)
+                .add(Items.GUSTER_BANNER_PATTERN.builtInRegistryHolder(), new EssenceValue(fabric, 1, knowledge, 1),
+                        false)
+                .add(Items.FIELD_MASONED_BANNER_PATTERN.builtInRegistryHolder(),
+                        new EssenceValue(fabric, 1, knowledge, 1), false)
+                .add(Items.BORDURE_INDENTED_BANNER_PATTERN.builtInRegistryHolder(),
+                        new EssenceValue(fabric, 1, knowledge, 1), false);
 
         // Workstations
         this.builder(ModDataMaps.ESSENCE_VALUE_DATA)
@@ -386,7 +391,6 @@ public class ModDataMapProvider extends DataMapProvider {
                 .add(Items.GRINDSTONE.builtInRegistryHolder(), new EssenceValue(earth, 1, chaos, 1), false)
                 .add(Items.SMITHING_TABLE.builtInRegistryHolder(), new EssenceValue(metal, 1, order, 1), false)
                 .add(Items.STONECUTTER.builtInRegistryHolder(), new EssenceValue(earth, 1, order, 1), false)
-
 
         ;
 
@@ -444,7 +448,8 @@ public class ModDataMapProvider extends DataMapProvider {
 
                 .add(Tags.Items.COBBLESTONES_MOSSY, new EssenceValue(earth, 1, plant, 1), false)
                 .add(Items.MOSSY_COBBLESTONE_SLAB.builtInRegistryHolder(), new EssenceValue(earth, 1, plant, 1), false)
-                .add(Items.MOSSY_COBBLESTONE_STAIRS.builtInRegistryHolder(), new EssenceValue(earth, 1, plant, 1), false)
+                .add(Items.MOSSY_COBBLESTONE_STAIRS.builtInRegistryHolder(), new EssenceValue(earth, 1, plant, 1),
+                        false)
                 .add(Items.MOSSY_COBBLESTONE_WALL.builtInRegistryHolder(), new EssenceValue(earth, 1, plant, 1), false)
 
                 .add(Tags.Items.COBBLESTONES_DEEPSLATE, new EssenceValue(earth, 1), false)
@@ -464,7 +469,6 @@ public class ModDataMapProvider extends DataMapProvider {
                 .add(Items.BASALT.builtInRegistryHolder(), new EssenceValue(earth, 1, fire, 1), false)
                 .add(Items.SMOOTH_BASALT.builtInRegistryHolder(), new EssenceValue(earth, 1, fire, 1), false)
                 .add(Items.POLISHED_BASALT.builtInRegistryHolder(), new EssenceValue(earth, 1, fire, 1), false)
-
 
                 .add(Items.POLISHED_ANDESITE.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
                 .add(Items.POLISHED_ANDESITE_SLAB.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
@@ -531,7 +535,8 @@ public class ModDataMapProvider extends DataMapProvider {
                 .add(Items.STONE_BRICK_WALL.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
                 .add(Items.MOSSY_STONE_BRICKS.builtInRegistryHolder(), new EssenceValue(earth, 1, plant, 1), false)
                 .add(Items.MOSSY_STONE_BRICK_SLAB.builtInRegistryHolder(), new EssenceValue(earth, 1, plant, 1), false)
-                .add(Items.MOSSY_STONE_BRICK_STAIRS.builtInRegistryHolder(), new EssenceValue(earth, 1, plant, 1), false)
+                .add(Items.MOSSY_STONE_BRICK_STAIRS.builtInRegistryHolder(), new EssenceValue(earth, 1, plant, 1),
+                        false)
                 .add(Items.MOSSY_STONE_BRICK_WALL.builtInRegistryHolder(), new EssenceValue(earth, 1, plant, 1), false)
                 .add(Items.TUFF_BRICKS.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
                 .add(Items.TUFF_BRICK_SLAB.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
@@ -542,7 +547,8 @@ public class ModDataMapProvider extends DataMapProvider {
                 .add(Items.POLISHED_BLACKSTONE_BRICK_SLAB.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
                 .add(Items.POLISHED_BLACKSTONE_BRICK_STAIRS.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
                 .add(Items.POLISHED_BLACKSTONE_BRICK_WALL.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
-                .add(Items.CRACKED_POLISHED_BLACKSTONE_BRICKS.builtInRegistryHolder(), new EssenceValue(earth, 1), false);
+                .add(Items.CRACKED_POLISHED_BLACKSTONE_BRICKS.builtInRegistryHolder(), new EssenceValue(earth, 1),
+                        false);
 
         // Nether Stone
         this.builder(ModDataMaps.ESSENCE_VALUE_DATA)
@@ -556,7 +562,8 @@ public class ModDataMapProvider extends DataMapProvider {
                 .add(Items.CHISELED_NETHER_BRICKS.builtInRegistryHolder(), new EssenceValue(nether, 1, earth, 1), false)
                 .add(Items.RED_NETHER_BRICKS.builtInRegistryHolder(), new EssenceValue(nether, 1, earth, 1), false)
                 .add(Items.RED_NETHER_BRICK_SLAB.builtInRegistryHolder(), new EssenceValue(nether, 1, earth, 1), false)
-                .add(Items.RED_NETHER_BRICK_STAIRS.builtInRegistryHolder(), new EssenceValue(nether, 1, earth, 1), false)
+                .add(Items.RED_NETHER_BRICK_STAIRS.builtInRegistryHolder(), new EssenceValue(nether, 1, earth, 1),
+                        false)
                 .add(Items.RED_NETHER_BRICK_WALL.builtInRegistryHolder(), new EssenceValue(nether, 1, earth, 1), false)
                 .add(Items.SOUL_SAND.builtInRegistryHolder(), new EssenceValue(earth, 1, nether, 1), false)
                 .add(Items.SOUL_SOIL.builtInRegistryHolder(), new EssenceValue(earth, 1, nether, 1), false);
@@ -677,7 +684,8 @@ public class ModDataMapProvider extends DataMapProvider {
                 .add(Items.LAPIS_BLOCK.builtInRegistryHolder(), new EssenceValue(crystal, 1), false)
                 .add(Items.QUARTZ.builtInRegistryHolder(), new EssenceValue(crystal, 1, nether, 1), false)
                 .add(Items.QUARTZ_BLOCK.builtInRegistryHolder(), new EssenceValue(crystal, 1, nether, 1), false)
-                .add(Items.CHISELED_QUARTZ_BLOCK.builtInRegistryHolder(), new EssenceValue(crystal, 1, nether, 1), false)
+                .add(Items.CHISELED_QUARTZ_BLOCK.builtInRegistryHolder(), new EssenceValue(crystal, 1, nether, 1),
+                        false)
                 .add(Items.QUARTZ_BRICKS.builtInRegistryHolder(), new EssenceValue(crystal, 1, nether, 1), false)
                 .add(Items.QUARTZ_SLAB.builtInRegistryHolder(), new EssenceValue(crystal, 1, nether, 1), false)
                 .add(Items.QUARTZ_PILLAR.builtInRegistryHolder(), new EssenceValue(crystal, 1, nether, 1), false)
@@ -715,7 +723,8 @@ public class ModDataMapProvider extends DataMapProvider {
                 .add(Items.STONE_PRESSURE_PLATE.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
                 .add(Items.LIGHT_WEIGHTED_PRESSURE_PLATE.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
                 .add(Items.HEAVY_WEIGHTED_PRESSURE_PLATE.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
-                .add(Items.POLISHED_BLACKSTONE_PRESSURE_PLATE.builtInRegistryHolder(), new EssenceValue(earth, 1), false);
+                .add(Items.POLISHED_BLACKSTONE_PRESSURE_PLATE.builtInRegistryHolder(), new EssenceValue(earth, 1),
+                        false);
 
         // Wooden Structures
         this.builder(ModDataMaps.ESSENCE_VALUE_DATA)
@@ -794,7 +803,8 @@ public class ModDataMapProvider extends DataMapProvider {
                 .add(Items.BOOKSHELF.builtInRegistryHolder(), new EssenceValue(order, 1, knowledge, 1), false)
                 .add(Items.CHISELED_BOOKSHELF.builtInRegistryHolder(), new EssenceValue(order, 1, knowledge, 1), false)
                 .add(Items.ENCHANTING_TABLE.builtInRegistryHolder(), new EssenceValue(knowledge, 1), false)
-                .add(Items.ENCHANTED_GOLDEN_APPLE.builtInRegistryHolder(), new EssenceValue(plant, 1, knowledge, 1), false)
+                .add(Items.ENCHANTED_GOLDEN_APPLE.builtInRegistryHolder(), new EssenceValue(plant, 1, knowledge, 1),
+                        false)
                 .add(Items.BEACON.builtInRegistryHolder(), new EssenceValue(knowledge, 1, crystal, 1), false)
                 .add(Items.CONDUIT.builtInRegistryHolder(), new EssenceValue(knowledge, 1, water, 1), false)
                 .add(Items.HEART_OF_THE_SEA.builtInRegistryHolder(), new EssenceValue(water, 1, crystal, 1), false)
@@ -812,25 +822,44 @@ public class ModDataMapProvider extends DataMapProvider {
                 .add(Items.WIND_CHARGE.builtInRegistryHolder(), new EssenceValue(air, 1), false)
                 .add(Items.DRAGON_BREATH.builtInRegistryHolder(), new EssenceValue(end, 1), false)
 
-                .add(Items.NETHERITE_UPGRADE_SMITHING_TEMPLATE.builtInRegistryHolder(), new EssenceValue(knowledge, 1), false)
-                .add(Items.SENTRY_ARMOR_TRIM_SMITHING_TEMPLATE.builtInRegistryHolder(), new EssenceValue(knowledge, 1), false)
-                .add(Items.DUNE_ARMOR_TRIM_SMITHING_TEMPLATE.builtInRegistryHolder(), new EssenceValue(knowledge, 1), false)
-                .add(Items.COAST_ARMOR_TRIM_SMITHING_TEMPLATE.builtInRegistryHolder(), new EssenceValue(knowledge, 1), false)
-                .add(Items.WILD_ARMOR_TRIM_SMITHING_TEMPLATE.builtInRegistryHolder(), new EssenceValue(knowledge, 1), false)
-                .add(Items.WARD_ARMOR_TRIM_SMITHING_TEMPLATE.builtInRegistryHolder(), new EssenceValue(knowledge, 1), false)
-                .add(Items.EYE_ARMOR_TRIM_SMITHING_TEMPLATE.builtInRegistryHolder(), new EssenceValue(knowledge, 1), false)
-                .add(Items.VEX_ARMOR_TRIM_SMITHING_TEMPLATE.builtInRegistryHolder(), new EssenceValue(knowledge, 1), false)
-                .add(Items.TIDE_ARMOR_TRIM_SMITHING_TEMPLATE.builtInRegistryHolder(), new EssenceValue(knowledge, 1), false)
-                .add(Items.SNOUT_ARMOR_TRIM_SMITHING_TEMPLATE.builtInRegistryHolder(), new EssenceValue(knowledge, 1), false)
-                .add(Items.RIB_ARMOR_TRIM_SMITHING_TEMPLATE.builtInRegistryHolder(), new EssenceValue(knowledge, 1), false)
-                .add(Items.SPIRE_ARMOR_TRIM_SMITHING_TEMPLATE.builtInRegistryHolder(), new EssenceValue(knowledge, 1), false)
-                .add(Items.WAYFINDER_ARMOR_TRIM_SMITHING_TEMPLATE.builtInRegistryHolder(), new EssenceValue(knowledge, 1), false)
-                .add(Items.SHAPER_ARMOR_TRIM_SMITHING_TEMPLATE.builtInRegistryHolder(), new EssenceValue(knowledge, 1), false)
-                .add(Items.SILENCE_ARMOR_TRIM_SMITHING_TEMPLATE.builtInRegistryHolder(), new EssenceValue(knowledge, 1), false)
-                .add(Items.RAISER_ARMOR_TRIM_SMITHING_TEMPLATE.builtInRegistryHolder(), new EssenceValue(knowledge, 1), false)
-                .add(Items.HOST_ARMOR_TRIM_SMITHING_TEMPLATE.builtInRegistryHolder(), new EssenceValue(knowledge, 1), false)
-                .add(Items.FLOW_ARMOR_TRIM_SMITHING_TEMPLATE.builtInRegistryHolder(), new EssenceValue(knowledge, 1), false)
-                .add(Items.BOLT_ARMOR_TRIM_SMITHING_TEMPLATE.builtInRegistryHolder(), new EssenceValue(knowledge, 1), false);
+                .add(Items.NETHERITE_UPGRADE_SMITHING_TEMPLATE.builtInRegistryHolder(), new EssenceValue(knowledge, 1),
+                        false)
+                .add(Items.SENTRY_ARMOR_TRIM_SMITHING_TEMPLATE.builtInRegistryHolder(), new EssenceValue(knowledge, 1),
+                        false)
+                .add(Items.DUNE_ARMOR_TRIM_SMITHING_TEMPLATE.builtInRegistryHolder(), new EssenceValue(knowledge, 1),
+                        false)
+                .add(Items.COAST_ARMOR_TRIM_SMITHING_TEMPLATE.builtInRegistryHolder(), new EssenceValue(knowledge, 1),
+                        false)
+                .add(Items.WILD_ARMOR_TRIM_SMITHING_TEMPLATE.builtInRegistryHolder(), new EssenceValue(knowledge, 1),
+                        false)
+                .add(Items.WARD_ARMOR_TRIM_SMITHING_TEMPLATE.builtInRegistryHolder(), new EssenceValue(knowledge, 1),
+                        false)
+                .add(Items.EYE_ARMOR_TRIM_SMITHING_TEMPLATE.builtInRegistryHolder(), new EssenceValue(knowledge, 1),
+                        false)
+                .add(Items.VEX_ARMOR_TRIM_SMITHING_TEMPLATE.builtInRegistryHolder(), new EssenceValue(knowledge, 1),
+                        false)
+                .add(Items.TIDE_ARMOR_TRIM_SMITHING_TEMPLATE.builtInRegistryHolder(), new EssenceValue(knowledge, 1),
+                        false)
+                .add(Items.SNOUT_ARMOR_TRIM_SMITHING_TEMPLATE.builtInRegistryHolder(), new EssenceValue(knowledge, 1),
+                        false)
+                .add(Items.RIB_ARMOR_TRIM_SMITHING_TEMPLATE.builtInRegistryHolder(), new EssenceValue(knowledge, 1),
+                        false)
+                .add(Items.SPIRE_ARMOR_TRIM_SMITHING_TEMPLATE.builtInRegistryHolder(), new EssenceValue(knowledge, 1),
+                        false)
+                .add(Items.WAYFINDER_ARMOR_TRIM_SMITHING_TEMPLATE.builtInRegistryHolder(),
+                        new EssenceValue(knowledge, 1), false)
+                .add(Items.SHAPER_ARMOR_TRIM_SMITHING_TEMPLATE.builtInRegistryHolder(), new EssenceValue(knowledge, 1),
+                        false)
+                .add(Items.SILENCE_ARMOR_TRIM_SMITHING_TEMPLATE.builtInRegistryHolder(), new EssenceValue(knowledge, 1),
+                        false)
+                .add(Items.RAISER_ARMOR_TRIM_SMITHING_TEMPLATE.builtInRegistryHolder(), new EssenceValue(knowledge, 1),
+                        false)
+                .add(Items.HOST_ARMOR_TRIM_SMITHING_TEMPLATE.builtInRegistryHolder(), new EssenceValue(knowledge, 1),
+                        false)
+                .add(Items.FLOW_ARMOR_TRIM_SMITHING_TEMPLATE.builtInRegistryHolder(), new EssenceValue(knowledge, 1),
+                        false)
+                .add(Items.BOLT_ARMOR_TRIM_SMITHING_TEMPLATE.builtInRegistryHolder(), new EssenceValue(knowledge, 1),
+                        false);
 
         // Light sources
         this.builder(ModDataMaps.ESSENCE_VALUE_DATA)
@@ -859,9 +888,12 @@ public class ModDataMapProvider extends DataMapProvider {
                 .add(Items.GLOWSTONE.builtInRegistryHolder(), new EssenceValue(nether, 1, light, 1), false)
                 .add(Items.JACK_O_LANTERN.builtInRegistryHolder(), new EssenceValue(light, 1, plant, 1), false)
                 .add(Items.SEA_LANTERN.builtInRegistryHolder(), new EssenceValue(light, 1, water, 1), false)
-                .add(Items.OCHRE_FROGLIGHT.builtInRegistryHolder(), new EssenceValue(light, 1, water, 1, life, 1), false)
-                .add(Items.VERDANT_FROGLIGHT.builtInRegistryHolder(), new EssenceValue(light, 1, water, 1, life, 1), false)
-                .add(Items.PEARLESCENT_FROGLIGHT.builtInRegistryHolder(), new EssenceValue(light, 1, water, 1, life, 1), false);
+                .add(Items.OCHRE_FROGLIGHT.builtInRegistryHolder(), new EssenceValue(light, 1, water, 1, life, 1),
+                        false)
+                .add(Items.VERDANT_FROGLIGHT.builtInRegistryHolder(), new EssenceValue(light, 1, water, 1, life, 1),
+                        false)
+                .add(Items.PEARLESCENT_FROGLIGHT.builtInRegistryHolder(), new EssenceValue(light, 1, water, 1, life, 1),
+                        false);
 
         // Archaeology
         this.builder(ModDataMaps.ESSENCE_VALUE_DATA)
@@ -887,19 +919,22 @@ public class ModDataMapProvider extends DataMapProvider {
                 .add(Items.IRON_SWORD.builtInRegistryHolder(), new EssenceValue(metal, 1, chaos, 1), false)
                 .add(Items.GOLDEN_SWORD.builtInRegistryHolder(), new EssenceValue(metal, 1, chaos, 1), false)
                 .add(Items.DIAMOND_SWORD.builtInRegistryHolder(), new EssenceValue(crystal, 1, chaos, 1), false)
-                .add(Items.NETHERITE_SWORD.builtInRegistryHolder(), new EssenceValue(nether, 1, metal, 1, chaos, 1), false)
+                .add(Items.NETHERITE_SWORD.builtInRegistryHolder(), new EssenceValue(nether, 1, metal, 1, chaos, 1),
+                        false)
                 .add(Items.WOODEN_AXE.builtInRegistryHolder(), new EssenceValue(plant, 1, chaos, 1), false)
                 .add(Items.STONE_AXE.builtInRegistryHolder(), new EssenceValue(earth, 1, chaos, 1), false)
                 .add(Items.IRON_AXE.builtInRegistryHolder(), new EssenceValue(metal, 1, chaos, 1), false)
                 .add(Items.GOLDEN_AXE.builtInRegistryHolder(), new EssenceValue(metal, 1, chaos, 1), false)
                 .add(Items.DIAMOND_AXE.builtInRegistryHolder(), new EssenceValue(crystal, 1, chaos, 1), false)
-                .add(Items.NETHERITE_AXE.builtInRegistryHolder(), new EssenceValue(metal, 1, nether, 1, chaos, 1), false)
+                .add(Items.NETHERITE_AXE.builtInRegistryHolder(), new EssenceValue(metal, 1, nether, 1, chaos, 1),
+                        false)
                 .add(Items.WOODEN_SHOVEL.builtInRegistryHolder(), new EssenceValue(plant, 1, earth, 1), false)
                 .add(Items.STONE_SHOVEL.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
                 .add(Items.IRON_SHOVEL.builtInRegistryHolder(), new EssenceValue(metal, 1, earth, 1), false)
                 .add(Items.GOLDEN_SHOVEL.builtInRegistryHolder(), new EssenceValue(metal, 1, earth, 1), false)
                 .add(Items.DIAMOND_SHOVEL.builtInRegistryHolder(), new EssenceValue(crystal, 1, earth, 1), false)
-                .add(Items.NETHERITE_SHOVEL.builtInRegistryHolder(), new EssenceValue(metal, 1, nether, 1, earth, 1), false)
+                .add(Items.NETHERITE_SHOVEL.builtInRegistryHolder(), new EssenceValue(metal, 1, nether, 1, earth, 1),
+                        false)
                 .add(Items.WOODEN_HOE.builtInRegistryHolder(), new EssenceValue(plant, 1, life, 1), false)
                 .add(Items.STONE_HOE.builtInRegistryHolder(), new EssenceValue(earth, 1, life, 1), false)
                 .add(Items.IRON_HOE.builtInRegistryHolder(), new EssenceValue(metal, 1, life, 1), false)
@@ -911,7 +946,8 @@ public class ModDataMapProvider extends DataMapProvider {
                 .add(Items.IRON_PICKAXE.builtInRegistryHolder(), new EssenceValue(metal, 1, earth, 1), false)
                 .add(Items.GOLDEN_PICKAXE.builtInRegistryHolder(), new EssenceValue(metal, 1, earth, 1), false)
                 .add(Items.DIAMOND_PICKAXE.builtInRegistryHolder(), new EssenceValue(crystal, 1, earth, 1), false)
-                .add(Items.NETHERITE_PICKAXE.builtInRegistryHolder(), new EssenceValue(metal, 1, nether, 1, earth, 1), false)
+                .add(Items.NETHERITE_PICKAXE.builtInRegistryHolder(), new EssenceValue(metal, 1, nether, 1, earth, 1),
+                        false)
 
                 .add(Items.LEATHER_HELMET.builtInRegistryHolder(), new EssenceValue(animal, 1), false)
                 .add(Items.LEATHER_CHESTPLATE.builtInRegistryHolder(), new EssenceValue(animal, 1), false)

--- a/src/main/java/com/wanderersoftherift/wotr/datagen/ModDataMapProvider.java
+++ b/src/main/java/com/wanderersoftherift/wotr/datagen/ModDataMapProvider.java
@@ -1,12 +1,12 @@
 package com.wanderersoftherift.wotr.datagen;
 
-import com.google.common.collect.ImmutableMap;
 import com.wanderersoftherift.wotr.WanderersOfTheRift;
 import com.wanderersoftherift.wotr.init.ModDataMaps;
 import com.wanderersoftherift.wotr.item.essence.EssenceValue;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.data.PackOutput;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.tags.ItemTags;
 import net.minecraft.world.item.Items;
 import net.neoforged.neoforge.common.Tags;
 import net.neoforged.neoforge.common.data.DataMapProvider;
@@ -23,24 +23,987 @@ public class ModDataMapProvider extends DataMapProvider {
         super(packOutput, lookupProvider);
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     protected void gather(HolderLookup.@NotNull Provider provider) {
-        ResourceLocation meat = WanderersOfTheRift.id("meat");
-        ResourceLocation earth = WanderersOfTheRift.id("earth");
-        ResourceLocation life = WanderersOfTheRift.id("life");
-        // Core
-        this.builder(ModDataMaps.ESSENCE_VALUE_DATA)
-                .add(Tags.Items.FOODS_RAW_MEAT, new EssenceValue(meat, 1), false)
-                .add(Tags.Items.FOODS_COOKED_MEAT, new EssenceValue(meat, 2), false)
-                .add(Tags.Items.COBBLESTONES, new EssenceValue(earth, 1), false)
-                .add(Tags.Items.STONES, new EssenceValue(earth, 2), false)
-                .add(Tags.Items.STRIPPED_LOGS, new EssenceValue(life, 8), false)
-                .add(Tags.Items.CROPS, new EssenceValue(life, 1), false)
-                .add(Items.POTATO.builtInRegistryHolder(),
-                        new EssenceValue(
-                                ImmutableMap.<ResourceLocation, Integer>builder().put(life, 2).put(earth, 1).build()),
-                        false)
-                .build();
+        ResourceLocation animal = WanderersOfTheRift.id("animal");
+        ResourceLocation plant = WanderersOfTheRift.id("plant");
 
+        ResourceLocation life = WanderersOfTheRift.id("life");
+        ResourceLocation death = WanderersOfTheRift.id("death");
+
+        ResourceLocation light = WanderersOfTheRift.id("light");
+        ResourceLocation dark = WanderersOfTheRift.id("dark");
+
+        ResourceLocation order = WanderersOfTheRift.id("order");
+        ResourceLocation chaos = WanderersOfTheRift.id("chaos");
+
+        ResourceLocation earth = WanderersOfTheRift.id("earth");
+        ResourceLocation fire = WanderersOfTheRift.id("fire");
+        ResourceLocation water = WanderersOfTheRift.id("water");
+        ResourceLocation air = WanderersOfTheRift.id("air");
+
+        ResourceLocation time = WanderersOfTheRift.id("time");
+        ResourceLocation space = WanderersOfTheRift.id("space");
+
+        ResourceLocation metal = WanderersOfTheRift.id("metal");
+        ResourceLocation fabric = WanderersOfTheRift.id("fabric");
+        ResourceLocation crystal = WanderersOfTheRift.id("crystal");
+        ResourceLocation power = WanderersOfTheRift.id("power");
+        ResourceLocation knowledge = WanderersOfTheRift.id("knowledge");
+
+        ResourceLocation nether = WanderersOfTheRift.id("nether");
+        ResourceLocation end = WanderersOfTheRift.id("end");
+
+        // Bee stuff
+        this.builder(ModDataMaps.ESSENCE_VALUE_DATA)
+                .add(Items.BEEHIVE.builtInRegistryHolder(), new EssenceValue(order, 1, animal, 1), false)
+                .add(Items.BEE_NEST.builtInRegistryHolder(), new EssenceValue(order, 1, animal, 1), false)
+                .add(Items.HONEY_BLOCK.builtInRegistryHolder(), new EssenceValue(water, 1, life, 1), false)
+                .add(Items.HONEY_BOTTLE.builtInRegistryHolder(), new EssenceValue(water, 1, life, 1), false)
+                .add(Items.HONEYCOMB.builtInRegistryHolder(), new EssenceValue(order, 1, life, 1), false)
+                .add(Items.HONEYCOMB_BLOCK.builtInRegistryHolder(), new EssenceValue(order, 1, life, 1), false);
+
+        // Flowers
+        this.builder(ModDataMaps.ESSENCE_VALUE_DATA)
+                .add(Items.DANDELION.builtInRegistryHolder(), new EssenceValue(plant, 1, life, 1), false)
+                .add(Items.POPPY.builtInRegistryHolder(), new EssenceValue(plant, 1, life, 1), false)
+                .add(Items.ALLIUM.builtInRegistryHolder(), new EssenceValue(plant, 1, life, 1), false)
+                .add(Items.AZURE_BLUET.builtInRegistryHolder(), new EssenceValue(plant, 1, life, 1), false)
+                .add(Items.RED_TULIP.builtInRegistryHolder(), new EssenceValue(plant, 1, life, 1), false)
+                .add(Items.ORANGE_TULIP.builtInRegistryHolder(), new EssenceValue(plant, 1, life, 1), false)
+                .add(Items.WHITE_TULIP.builtInRegistryHolder(), new EssenceValue(plant, 1, life, 1), false)
+                .add(Items.PINK_TULIP.builtInRegistryHolder(), new EssenceValue(plant, 1, life, 1), false)
+                .add(Items.OXEYE_DAISY.builtInRegistryHolder(), new EssenceValue(plant, 1, life, 1), false)
+                .add(Items.CORNFLOWER.builtInRegistryHolder(), new EssenceValue(plant, 1, life, 1), false)
+                .add(Items.LILY_OF_THE_VALLEY.builtInRegistryHolder(), new EssenceValue(plant, 1, life, 1), false)
+                .add(Items.TORCHFLOWER.builtInRegistryHolder(), new EssenceValue(plant, 1, life, 1), false)
+                .add(Items.OPEN_EYEBLOSSOM.builtInRegistryHolder(), new EssenceValue(plant, 1, light, 1), false)
+                .add(Items.CLOSED_EYEBLOSSOM.builtInRegistryHolder(), new EssenceValue(plant, 1, dark, 1), false)
+                .add(Items.WITHER_ROSE.builtInRegistryHolder(), new EssenceValue(plant, 1, death, 1), false)
+                .add(Tags.Items.FLOWERS_TALL, new EssenceValue(plant, 1), false)
+                .add(Items.BLUE_ORCHID.builtInRegistryHolder(), new EssenceValue(plant, 1, life, 1), false)
+                .add(Items.SPORE_BLOSSOM.builtInRegistryHolder(), new EssenceValue(plant, 1, life, 1), false)
+                .add(Items.PINK_PETALS.builtInRegistryHolder(), new EssenceValue(plant, 1), false);
+
+        // Trees
+        this.builder(ModDataMaps.ESSENCE_VALUE_DATA)
+                .add(ItemTags.LEAVES, new EssenceValue(plant, 1), false)
+                .add(ItemTags.SAPLINGS, new EssenceValue(plant, 1, life, 1), false)
+                .add(Items.STICK.builtInRegistryHolder(), new EssenceValue(plant, 1), false)
+                .add(ItemTags.OAK_LOGS, new EssenceValue(plant, 1), false)
+                .add(ItemTags.SPRUCE_LOGS, new EssenceValue(plant, 1), false)
+                .add(ItemTags.BIRCH_LOGS, new EssenceValue(plant, 1), false)
+                .add(ItemTags.JUNGLE_LOGS, new EssenceValue(plant, 1), false)
+                .add(ItemTags.ACACIA_LOGS, new EssenceValue(plant, 1), false)
+                .add(ItemTags.DARK_OAK_LOGS, new EssenceValue(plant, 1), false)
+                .add(ItemTags.MANGROVE_LOGS, new EssenceValue(plant, 1), false)
+                .add(ItemTags.CHERRY_LOGS, new EssenceValue(plant, 1), false)
+                .add(ItemTags.PALE_OAK_LOGS, new EssenceValue(plant, 1), false);
+
+        // Nether Plants
+        this.builder(ModDataMaps.ESSENCE_VALUE_DATA)
+                .add(Items.NETHER_WART.builtInRegistryHolder(), new EssenceValue(nether, 1, plant, 1), false)
+                .add(ItemTags.WART_BLOCKS, new EssenceValue(plant, 1, nether, 1), false)
+                .add(ItemTags.WARPED_STEMS, new EssenceValue(plant, 1, nether, 1), false)
+                .add(ItemTags.CRIMSON_STEMS, new EssenceValue(plant, 1, nether, 1), false)
+                .add(Items.CRIMSON_ROOTS.builtInRegistryHolder(), new EssenceValue(plant, 1, nether, 1), false)
+                .add(Items.WARPED_ROOTS.builtInRegistryHolder(), new EssenceValue(plant, 1, nether, 1), false)
+                .add(Items.NETHER_SPROUTS.builtInRegistryHolder(), new EssenceValue(plant, 1, nether, 1), false)
+                .add(Items.WEEPING_VINES.builtInRegistryHolder(), new EssenceValue(plant, 1, nether, 1), false)
+                .add(Items.TWISTING_VINES.builtInRegistryHolder(), new EssenceValue(plant, 1, nether, 1), false);
+
+        // Wood
+        this.builder(ModDataMaps.ESSENCE_VALUE_DATA)
+                .add(ItemTags.PLANKS, new EssenceValue(plant, 1), false)
+                .add(ItemTags.WOODEN_SLABS, new EssenceValue(plant, 1), false)
+                .add(ItemTags.WOODEN_STAIRS, new EssenceValue(plant, 1), false);
+
+        // Bamboo
+        this.builder(ModDataMaps.ESSENCE_VALUE_DATA)
+                .add(Items.BAMBOO.builtInRegistryHolder(), new EssenceValue(plant, 1), false)
+                .add(ItemTags.BAMBOO_BLOCKS, new EssenceValue(plant, 1), false)
+                .add(Items.BAMBOO_MOSAIC.builtInRegistryHolder(), new EssenceValue(plant, 1), false)
+                .add(Items.BAMBOO_MOSAIC_SLAB.builtInRegistryHolder(), new EssenceValue(plant, 1), false)
+                .add(Items.BAMBOO_MOSAIC_STAIRS.builtInRegistryHolder(), new EssenceValue(plant, 1), false);
+
+        // Crops and Berries
+        this.builder(ModDataMaps.ESSENCE_VALUE_DATA)
+                .add(Items.APPLE.builtInRegistryHolder(), new EssenceValue(plant, 1, life, 1), false)
+                .add(Items.BEETROOT.builtInRegistryHolder(), new EssenceValue(plant, 1, life, 1), false)
+                .add(Items.CACTUS.builtInRegistryHolder(), new EssenceValue(plant, 1, life, 1), false)
+                .add(Items.CARROT.builtInRegistryHolder(), new EssenceValue(plant, 1, life, 1), false)
+                .add(Items.COCOA_BEANS.builtInRegistryHolder(), new EssenceValue(plant, 1, life, 1), false)
+                .add(Items.MELON.builtInRegistryHolder(), new EssenceValue(plant, 1, life, 1), false)
+                .add(Items.MELON_SLICE.builtInRegistryHolder(), new EssenceValue(plant, 1, life, 1), false)
+                .add(Items.PUMPKIN.builtInRegistryHolder(), new EssenceValue(plant, 1, life, 1), false)
+                .add(Items.CARVED_PUMPKIN.builtInRegistryHolder(), new EssenceValue(plant, 1), false)
+                .add(Items.POTATO.builtInRegistryHolder(), new EssenceValue(plant, 1, life, 1), false)
+                .add(Items.POISONOUS_POTATO.builtInRegistryHolder(), new EssenceValue(plant, 1, life, 1), false)
+                .add(Items.SUGAR_CANE.builtInRegistryHolder(), new EssenceValue(plant, 1, life, 1), false)
+                .add(Items.WHEAT.builtInRegistryHolder(), new EssenceValue(plant, 1, life, 1), false)
+                .add(Items.HAY_BLOCK.builtInRegistryHolder(), new EssenceValue(plant, 1, life, 1), false)
+                .add(Items.SWEET_BERRIES.builtInRegistryHolder(), new EssenceValue(plant, 1, life, 1), false)
+                .add(Items.GLOW_BERRIES.builtInRegistryHolder(), new EssenceValue(plant, 1, light, 1), false);
+
+        // Seeds
+        this.builder(ModDataMaps.ESSENCE_VALUE_DATA)
+                .add(Tags.Items.SEEDS, new EssenceValue(plant, 1, life, 1), false);
+
+        // Fungi
+        this.builder(ModDataMaps.ESSENCE_VALUE_DATA)
+                .add(Tags.Items.MUSHROOMS, new EssenceValue(life, 1), false)
+                .add(Items.MUSHROOM_STEM.builtInRegistryHolder(), new EssenceValue(life, 1), false)
+                .add(Items.BROWN_MUSHROOM_BLOCK.builtInRegistryHolder(), new EssenceValue(life, 1), false)
+                .add(Items.MYCELIUM.builtInRegistryHolder(), new EssenceValue(earth, 1, life, 1), false)
+                .add(Items.RED_MUSHROOM_BLOCK.builtInRegistryHolder(), new EssenceValue(life, 1), false)
+                .add(Items.CRIMSON_NYLIUM.builtInRegistryHolder(), new EssenceValue(earth, 1, nether, 1), false)
+                .add(Items.WARPED_NYLIUM.builtInRegistryHolder(), new EssenceValue(earth, 1, nether, 1), false)
+                .add(Items.CRIMSON_FUNGUS.builtInRegistryHolder(), new EssenceValue(life, 1, nether, 1), false)
+                .add(Items.WARPED_FUNGUS.builtInRegistryHolder(), new EssenceValue(life, 1, nether, 1), false)
+                .add(Items.GLOW_LICHEN.builtInRegistryHolder(), new EssenceValue(life, 1, light, 1), false);
+
+        // Grasses, ground & wall covers
+        this.builder(ModDataMaps.ESSENCE_VALUE_DATA)
+                .add(Items.VINE.builtInRegistryHolder(), new EssenceValue(plant, 1), false)
+                .add(Items.GRASS_BLOCK.builtInRegistryHolder(), new EssenceValue(plant, 1, earth, 1), false)
+                .add(Items.PODZOL.builtInRegistryHolder(), new EssenceValue(plant, 1, earth, 1), false)
+                .add(Items.SHORT_GRASS.builtInRegistryHolder(), new EssenceValue(plant, 1), false)
+                .add(Items.TALL_GRASS.builtInRegistryHolder(), new EssenceValue(plant, 1), false)
+                .add(Items.FERN.builtInRegistryHolder(), new EssenceValue(plant, 1), false)
+                .add(Items.LARGE_FERN.builtInRegistryHolder(), new EssenceValue(plant, 1), false)
+                .add(Items.DEAD_BUSH.builtInRegistryHolder(), new EssenceValue(plant, 1), false)
+                .add(Items.MOSS_CARPET.builtInRegistryHolder(), new EssenceValue(plant, 1), false)
+                .add(Items.MOSS_BLOCK.builtInRegistryHolder(), new EssenceValue(plant, 1), false)
+                .add(Items.PALE_MOSS_CARPET.builtInRegistryHolder(), new EssenceValue(plant, 1), false)
+                .add(Items.PALE_MOSS_BLOCK.builtInRegistryHolder(), new EssenceValue(plant, 1), false)
+                .add(Items.PALE_HANGING_MOSS.builtInRegistryHolder(), new EssenceValue(plant, 1), false)
+                .add(Items.BIG_DRIPLEAF.builtInRegistryHolder(), new EssenceValue(plant, 1), false)
+                .add(Items.SMALL_DRIPLEAF.builtInRegistryHolder(), new EssenceValue(plant, 1), false);
+
+        // Roots
+        this.builder(ModDataMaps.ESSENCE_VALUE_DATA)
+                .add(Items.ROOTED_DIRT.builtInRegistryHolder(), new EssenceValue(plant, 1, earth, 1), false)
+                .add(Items.MANGROVE_ROOTS.builtInRegistryHolder(), new EssenceValue(plant, 1), false)
+                .add(Items.MUDDY_MANGROVE_ROOTS.builtInRegistryHolder(), new EssenceValue(plant, 1, earth, 1), false)
+                .add(Items.HANGING_ROOTS.builtInRegistryHolder(), new EssenceValue(plant, 1), false);
+
+        // Creaking related
+        this.builder(ModDataMaps.ESSENCE_VALUE_DATA)
+                .add(Items.CREAKING_HEART.builtInRegistryHolder(), new EssenceValue(life, 1, plant, 1), false)
+                .add(Items.RESIN_CLUMP.builtInRegistryHolder(), new EssenceValue(plant, 1, crystal, 1), false)
+                .add(Items.RESIN_BLOCK.builtInRegistryHolder(), new EssenceValue(plant, 1, crystal, 1), false)
+                .add(Items.RESIN_BRICK.builtInRegistryHolder(), new EssenceValue(plant, 1, crystal, 1), false)
+                .add(Items.RESIN_BRICKS.builtInRegistryHolder(), new EssenceValue(plant, 1, crystal, 1), false)
+                .add(Items.RESIN_BRICK_SLAB.builtInRegistryHolder(), new EssenceValue(plant, 1, crystal, 1), false)
+                .add(Items.RESIN_BRICK_STAIRS.builtInRegistryHolder(), new EssenceValue(plant, 1, crystal, 1), false)
+                .add(Items.RESIN_BRICK_WALL.builtInRegistryHolder(), new EssenceValue(plant, 1, crystal, 1), false)
+                .add(Items.CHISELED_RESIN_BRICKS.builtInRegistryHolder(), new EssenceValue(plant, 1, crystal, 1), false);
+
+        // End flora
+        this.builder(ModDataMaps.ESSENCE_VALUE_DATA)
+                .add(Items.CHORUS_PLANT.builtInRegistryHolder(), new EssenceValue(end, 1, plant, 1), false)
+                .add(Items.CHORUS_FLOWER.builtInRegistryHolder(), new EssenceValue(end, 1, plant, 1), false)
+                .add(Items.CHORUS_FRUIT.builtInRegistryHolder(), new EssenceValue(end, 1, space, 1, plant, 1), false)
+                .add(Items.POPPED_CHORUS_FRUIT.builtInRegistryHolder(), new EssenceValue(end, 1, plant, 1), false);
+
+        // Skulk
+        this.builder(ModDataMaps.ESSENCE_VALUE_DATA)
+                .add(Items.SCULK.builtInRegistryHolder(), new EssenceValue(dark, 1, life, 1), false)
+                .add(Items.SCULK_CATALYST.builtInRegistryHolder(), new EssenceValue(dark, 1, life, 1), false)
+                .add(Items.SCULK_SENSOR.builtInRegistryHolder(), new EssenceValue(dark, 1, life, 1), false)
+                .add(Items.SCULK_VEIN.builtInRegistryHolder(), new EssenceValue(dark, 1, life, 1), false)
+                .add(Items.SCULK_SHRIEKER.builtInRegistryHolder(), new EssenceValue(dark, 1, life, 1), false)
+                .add(Items.CALIBRATED_SCULK_SENSOR.builtInRegistryHolder(), new EssenceValue(dark, 1, crystal, 1), false);
+
+        // Water life
+        this.builder(ModDataMaps.ESSENCE_VALUE_DATA)
+                .add(Items.PUFFERFISH_BUCKET.builtInRegistryHolder(), new EssenceValue(water, 1, animal, 1), false)
+                .add(Items.SALMON_BUCKET.builtInRegistryHolder(), new EssenceValue(water, 1, animal, 1), false)
+                .add(Items.COD_BUCKET.builtInRegistryHolder(), new EssenceValue(water, 1, animal, 1), false)
+                .add(Items.TROPICAL_FISH_BUCKET.builtInRegistryHolder(), new EssenceValue(water, 1, animal, 1), false)
+                .add(Items.AXOLOTL_BUCKET.builtInRegistryHolder(), new EssenceValue(water, 1, animal, 1), false)
+                .add(Items.TADPOLE_BUCKET.builtInRegistryHolder(), new EssenceValue(water, 1, animal, 1), false)
+                .add(Items.NAUTILUS_SHELL.builtInRegistryHolder(), new EssenceValue(water, 1, animal, 1), false)
+
+
+                .add(Items.SPONGE.builtInRegistryHolder(), new EssenceValue(water, 1), false)
+                .add(Items.WET_SPONGE.builtInRegistryHolder(), new EssenceValue(water, 1), false)
+                .add(Items.SEAGRASS.builtInRegistryHolder(), new EssenceValue(plant, 1, water, 1), false)
+                .add(Items.SEA_PICKLE.builtInRegistryHolder(), new EssenceValue(plant, 1, water, 1), false)
+                .add(Items.KELP.builtInRegistryHolder(), new EssenceValue(plant, 1, water, 1), false)
+                .add(Items.DRIED_KELP.builtInRegistryHolder(), new EssenceValue(plant, 1), false)
+                .add(Items.DRIED_KELP_BLOCK.builtInRegistryHolder(), new EssenceValue(plant, 1), false)
+                .add(Items.LILY_PAD.builtInRegistryHolder(), new EssenceValue(plant, 1, water, 1), false)
+
+                .add(Items.BRAIN_CORAL.builtInRegistryHolder(), new EssenceValue(plant, 1, water, 1), false)
+                .add(Items.BRAIN_CORAL_BLOCK.builtInRegistryHolder(), new EssenceValue(plant, 1, water, 1), false)
+                .add(Items.BRAIN_CORAL_FAN.builtInRegistryHolder(), new EssenceValue(plant, 1, water, 1), false)
+                .add(Items.BUBBLE_CORAL.builtInRegistryHolder(), new EssenceValue(plant, 1, water, 1), false)
+                .add(Items.BUBBLE_CORAL_BLOCK.builtInRegistryHolder(), new EssenceValue(plant, 1, water, 1), false)
+                .add(Items.BUBBLE_CORAL_FAN.builtInRegistryHolder(), new EssenceValue(plant, 1, water, 1), false)
+                .add(Items.FIRE_CORAL.builtInRegistryHolder(), new EssenceValue(plant, 1, water, 1), false)
+                .add(Items.FIRE_CORAL_BLOCK.builtInRegistryHolder(), new EssenceValue(plant, 1, water, 1), false)
+                .add(Items.FIRE_CORAL_FAN.builtInRegistryHolder(), new EssenceValue(plant, 1, water, 1), false)
+                .add(Items.HORN_CORAL.builtInRegistryHolder(), new EssenceValue(plant, 1, water, 1), false)
+                .add(Items.HORN_CORAL_BLOCK.builtInRegistryHolder(), new EssenceValue(plant, 1, water, 1), false)
+                .add(Items.HORN_CORAL_FAN.builtInRegistryHolder(), new EssenceValue(plant, 1, water, 1), false)
+                .add(Items.TUBE_CORAL.builtInRegistryHolder(), new EssenceValue(plant, 1, water, 1), false)
+                .add(Items.TUBE_CORAL_BLOCK.builtInRegistryHolder(), new EssenceValue(plant, 1, water, 1), false)
+                .add(Items.TUBE_CORAL_FAN.builtInRegistryHolder(), new EssenceValue(plant, 1, water, 1), false)
+
+                .add(Items.DEAD_BRAIN_CORAL.builtInRegistryHolder(), new EssenceValue(plant, 1, water, 1), false)
+                .add(Items.DEAD_BRAIN_CORAL_BLOCK.builtInRegistryHolder(), new EssenceValue(plant, 1, water, 1), false)
+                .add(Items.DEAD_BRAIN_CORAL_FAN.builtInRegistryHolder(), new EssenceValue(plant, 1, water, 1), false)
+                .add(Items.DEAD_BUBBLE_CORAL.builtInRegistryHolder(), new EssenceValue(plant, 1, water, 1), false)
+                .add(Items.DEAD_BUBBLE_CORAL_BLOCK.builtInRegistryHolder(), new EssenceValue(plant, 1, water, 1), false)
+                .add(Items.DEAD_BUBBLE_CORAL_FAN.builtInRegistryHolder(), new EssenceValue(plant, 1, water, 1), false)
+                .add(Items.DEAD_FIRE_CORAL.builtInRegistryHolder(), new EssenceValue(plant, 1, water, 1), false)
+                .add(Items.DEAD_FIRE_CORAL_BLOCK.builtInRegistryHolder(), new EssenceValue(plant, 1, water, 1), false)
+                .add(Items.DEAD_FIRE_CORAL_FAN.builtInRegistryHolder(), new EssenceValue(plant, 1, water, 1), false)
+                .add(Items.DEAD_HORN_CORAL.builtInRegistryHolder(), new EssenceValue(plant, 1, water, 1), false)
+                .add(Items.DEAD_HORN_CORAL_BLOCK.builtInRegistryHolder(), new EssenceValue(plant, 1, water, 1), false)
+                .add(Items.DEAD_HORN_CORAL_FAN.builtInRegistryHolder(), new EssenceValue(plant, 1, water, 1), false)
+                .add(Items.DEAD_TUBE_CORAL.builtInRegistryHolder(), new EssenceValue(plant, 1, water, 1), false)
+                .add(Items.DEAD_TUBE_CORAL_BLOCK.builtInRegistryHolder(), new EssenceValue(plant, 1, water, 1), false)
+                .add(Items.DEAD_TUBE_CORAL_FAN.builtInRegistryHolder(), new EssenceValue(plant, 1, water, 1), false);
+
+        // Water
+        this.builder(ModDataMaps.ESSENCE_VALUE_DATA)
+                .add(Items.WATER_BUCKET.builtInRegistryHolder(), new EssenceValue(water, 1), false)
+                .add(Items.POWDER_SNOW_BUCKET.builtInRegistryHolder(), new EssenceValue(water, 1), false)
+                .add(Items.SNOWBALL.builtInRegistryHolder(), new EssenceValue(water, 1), false)
+                .add(Items.SNOW.builtInRegistryHolder(), new EssenceValue(water, 1), false)
+                .add(Items.SNOW_BLOCK.builtInRegistryHolder(), new EssenceValue(water, 1), false)
+                .add(Items.ICE.builtInRegistryHolder(), new EssenceValue(water, 1), false)
+                .add(Items.BLUE_ICE.builtInRegistryHolder(), new EssenceValue(water, 1), false)
+                .add(Items.PACKED_ICE.builtInRegistryHolder(), new EssenceValue(water, 1), false);
+
+        // Meats
+        this.builder(ModDataMaps.ESSENCE_VALUE_DATA)
+                .add(Tags.Items.FOODS_RAW_MEAT, new EssenceValue(animal, 1), false)
+                .add(Tags.Items.FOODS_RAW_FISH, new EssenceValue(animal, 1, water, 1), false);
+
+        // Animal products
+        this.builder(ModDataMaps.ESSENCE_VALUE_DATA)
+                .add(Items.ARMADILLO_SCUTE.builtInRegistryHolder(), new EssenceValue(animal, 1), false)
+                .add(Items.TURTLE_SCUTE.builtInRegistryHolder(), new EssenceValue(animal, 1, water, 1), false)
+                .add(Items.FEATHER.builtInRegistryHolder(), new EssenceValue(animal, 1, air, 1), false)
+                .add(Items.LEATHER.builtInRegistryHolder(), new EssenceValue(animal, 1), false)
+                .add(Items.RABBIT_HIDE.builtInRegistryHolder(), new EssenceValue(animal, 1), false)
+                .add(Items.RABBIT_FOOT.builtInRegistryHolder(), new EssenceValue(animal, 1, chaos, 1), false)
+                .add(Items.MILK_BUCKET.builtInRegistryHolder(), new EssenceValue(animal, 1, water, 1), false)
+                .add(Items.INK_SAC.builtInRegistryHolder(), new EssenceValue(animal, 1, water, 1), false)
+                .add(Items.GLOW_INK_SAC.builtInRegistryHolder(), new EssenceValue(animal, 1, light, 1), false);
+
+        // Foods
+        this.builder(ModDataMaps.ESSENCE_VALUE_DATA)
+                .add(Items.SUGAR.builtInRegistryHolder(), new EssenceValue(life, 1), false)
+                .add(Items.CAKE.builtInRegistryHolder(), new EssenceValue(life, 1), false)
+                .add(Items.COOKIE.builtInRegistryHolder(), new EssenceValue(life, 1), false)
+                .add(Tags.Items.FOODS_COOKED_FISH, new EssenceValue(life, 1, animal, 1), false)
+                .add(Tags.Items.FOODS_COOKED_MEAT, new EssenceValue(life, 1, animal, 1), false)
+                .add(Items.PUMPKIN_PIE.builtInRegistryHolder(), new EssenceValue(life, 1, plant, 1), false)
+                .add(Items.MUSHROOM_STEW.builtInRegistryHolder(), new EssenceValue(life, 1), false)
+                .add(Items.SUSPICIOUS_STEW.builtInRegistryHolder(), new EssenceValue(chaos, 1), false)
+                .add(Items.BREAD.builtInRegistryHolder(), new EssenceValue(life, 1), false)
+                .add(Items.GOLDEN_CARROT.builtInRegistryHolder(), new EssenceValue(life, 1, metal, 1), false)
+                .add(Items.GOLDEN_APPLE.builtInRegistryHolder(), new EssenceValue(life, 1, metal, 1), false)
+                .add(Items.GLISTERING_MELON_SLICE.builtInRegistryHolder(), new EssenceValue(life, 1, metal, 1), false)
+                .add(Items.FERMENTED_SPIDER_EYE.builtInRegistryHolder(), new EssenceValue(animal, 1), false)
+                .add(Items.BAKED_POTATO.builtInRegistryHolder(), new EssenceValue(plant, 1, life, 1), false)
+                .add(Items.RABBIT_STEW.builtInRegistryHolder(), new EssenceValue(animal, 1, life, 1), false)
+                .add(Items.BEETROOT_SOUP.builtInRegistryHolder(), new EssenceValue(plant, 1, life, 1), false)
+        ;
+
+        // Eggs
+        this.builder(ModDataMaps.ESSENCE_VALUE_DATA)
+                // TODO: 1.21.5 replace with eggs itemtag
+                .add(Items.EGG.builtInRegistryHolder(), new EssenceValue(animal, 1, life, 1), false)
+                .add(Items.TURTLE_EGG.builtInRegistryHolder(), new EssenceValue(animal, 1, life, 1), false)
+                .add(Items.SNIFFER_EGG.builtInRegistryHolder(), new EssenceValue(animal, 1, life, 1), false)
+                .add(Items.DRAGON_EGG.builtInRegistryHolder(), new EssenceValue(end, 1, life, 1), false);
+
+        // Mob drops
+        this.builder(ModDataMaps.ESSENCE_VALUE_DATA)
+                .add(Items.SLIME_BALL.builtInRegistryHolder(), new EssenceValue(water, 1, animal, 1), false)
+                .add(Items.SLIME_BLOCK.builtInRegistryHolder(), new EssenceValue(water, 1, animal, 1), false)
+                .add(Items.SPIDER_EYE.builtInRegistryHolder(), new EssenceValue(animal, 1), false)
+                .add(Items.COBWEB.builtInRegistryHolder(), new EssenceValue(animal, 1, fabric, 1), false)
+                .add(Items.ROTTEN_FLESH.builtInRegistryHolder(), new EssenceValue(animal, 1, death, 1), false)
+                .add(Items.PHANTOM_MEMBRANE.builtInRegistryHolder(), new EssenceValue(chaos, 1), false)
+                .add(Items.BREEZE_ROD.builtInRegistryHolder(), new EssenceValue(air, 1), false)
+                .add(Items.BLAZE_ROD.builtInRegistryHolder(), new EssenceValue(fire, 1), false)
+                .add(Items.BLAZE_POWDER.builtInRegistryHolder(), new EssenceValue(fire, 1), false)
+                .add(ItemTags.SKULLS, new EssenceValue(death, 1), false)
+                .add(Items.GHAST_TEAR.builtInRegistryHolder(), new EssenceValue(nether, 1, death, 1), false)
+                .add(Items.ENDER_PEARL.builtInRegistryHolder(), new EssenceValue(end, 1, space, 1), false)
+                .add(Items.ENDER_EYE.builtInRegistryHolder(), new EssenceValue(space, 1, knowledge, 1), false)
+                .add(Items.MAGMA_CREAM.builtInRegistryHolder(), new EssenceValue(life, 1, fire, 1), false)
+                .add(Items.SHULKER_SHELL.builtInRegistryHolder(), new EssenceValue(animal, 1, end, 1), false)
+        ;
+
+        // Bones
+        this.builder(ModDataMaps.ESSENCE_VALUE_DATA)
+                .add(Items.BONE.builtInRegistryHolder(), new EssenceValue(animal, 1, death, 1), false)
+                .add(Items.BONE_BLOCK.builtInRegistryHolder(), new EssenceValue(animal, 1, death, 1), false)
+                .add(Items.BONE_MEAL.builtInRegistryHolder(), new EssenceValue(animal, 1, death, 1), false);
+
+        // Textiles
+        this.builder(ModDataMaps.ESSENCE_VALUE_DATA)
+                .add(Items.STRING.builtInRegistryHolder(), new EssenceValue(fabric, 1), false)
+                .add(ItemTags.WOOL, new EssenceValue(fabric, 1), false)
+                .add(ItemTags.WOOL_CARPETS, new EssenceValue(fabric, 1), false)
+                .add(ItemTags.BANNERS, new EssenceValue(fabric, 1, order, 1), false)
+                .add(ItemTags.BEDS, new EssenceValue(fabric, 1, order, 1), false)
+                .add(Tags.Items.DYES, new EssenceValue(order, 1, water, 1), false)
+                .add(Items.FLOWER_BANNER_PATTERN.builtInRegistryHolder(), new EssenceValue(fabric, 1, knowledge, 1), false)
+                .add(Items.CREEPER_BANNER_PATTERN.builtInRegistryHolder(), new EssenceValue(fabric, 1, knowledge, 1), false)
+                .add(Items.SKULL_BANNER_PATTERN.builtInRegistryHolder(), new EssenceValue(fabric, 1, knowledge, 1), false)
+                .add(Items.MOJANG_BANNER_PATTERN.builtInRegistryHolder(), new EssenceValue(fabric, 1, knowledge, 1), false)
+                .add(Items.GLOBE_BANNER_PATTERN.builtInRegistryHolder(), new EssenceValue(fabric, 1, knowledge, 1), false)
+                .add(Items.PIGLIN_BANNER_PATTERN.builtInRegistryHolder(), new EssenceValue(fabric, 1, knowledge, 1), false)
+                .add(Items.FLOW_BANNER_PATTERN.builtInRegistryHolder(), new EssenceValue(fabric, 1, knowledge, 1), false)
+                .add(Items.GUSTER_BANNER_PATTERN.builtInRegistryHolder(), new EssenceValue(fabric, 1, knowledge, 1), false)
+                .add(Items.FIELD_MASONED_BANNER_PATTERN.builtInRegistryHolder(), new EssenceValue(fabric, 1, knowledge, 1), false)
+                .add(Items.BORDURE_INDENTED_BANNER_PATTERN.builtInRegistryHolder(), new EssenceValue(fabric, 1, knowledge, 1), false)
+        ;
+
+        // Workstations
+        this.builder(ModDataMaps.ESSENCE_VALUE_DATA)
+                .add(Items.CRAFTING_TABLE.builtInRegistryHolder(), new EssenceValue(order, 1), false)
+                .add(ItemTags.ANVIL, new EssenceValue(metal, 1, order, 1), false)
+                .add(Items.FURNACE.builtInRegistryHolder(), new EssenceValue(fire, 1), false)
+                .add(Items.BLAST_FURNACE.builtInRegistryHolder(), new EssenceValue(fire, 1), false)
+                .add(Items.SMOKER.builtInRegistryHolder(), new EssenceValue(fire, 1), false)
+                .add(Items.CRAFTER.builtInRegistryHolder(), new EssenceValue(order, 1, power, 1), false)
+                .add(Items.BREWING_STAND.builtInRegistryHolder(), new EssenceValue(order, 1, knowledge, 1), false)
+                .add(Items.CAULDRON.builtInRegistryHolder(), new EssenceValue(metal, 1), false)
+                .add(Items.LOOM.builtInRegistryHolder(), new EssenceValue(fabric, 1, order, 1), false)
+                .add(Items.COMPOSTER.builtInRegistryHolder(), new EssenceValue(life, 1, plant, 1), false)
+                .add(Items.CARTOGRAPHY_TABLE.builtInRegistryHolder(), new EssenceValue(space, 1, order, 1), false)
+                .add(Items.FLETCHING_TABLE.builtInRegistryHolder(), new EssenceValue(air, 1, order, 1), false)
+                .add(Items.GRINDSTONE.builtInRegistryHolder(), new EssenceValue(earth, 1, chaos, 1), false)
+                .add(Items.SMITHING_TABLE.builtInRegistryHolder(), new EssenceValue(metal, 1, order, 1), false)
+                .add(Items.STONECUTTER.builtInRegistryHolder(), new EssenceValue(earth, 1, order, 1), false)
+
+
+        ;
+
+        // Transportation
+        this.builder(ModDataMaps.ESSENCE_VALUE_DATA)
+                .add(ItemTags.BOATS, new EssenceValue(order, 1, water, 1), false)
+                .add(ItemTags.CHEST_BOATS, new EssenceValue(order, 1, water, 1), false)
+                .add(Items.MINECART.builtInRegistryHolder(), new EssenceValue(order, 1), false)
+                .add(Items.FURNACE_MINECART.builtInRegistryHolder(), new EssenceValue(order, 1, fire, 1), false)
+                .add(Items.CHEST_MINECART.builtInRegistryHolder(), new EssenceValue(order, 1), false)
+                .add(Items.TNT_MINECART.builtInRegistryHolder(), new EssenceValue(order, 1, fire, 1), false)
+                .add(Items.HOPPER_MINECART.builtInRegistryHolder(), new EssenceValue(order, 1, metal, 1), false);
+
+        // Dirt
+        this.builder(ModDataMaps.ESSENCE_VALUE_DATA)
+                .add(ItemTags.SAND, new EssenceValue(earth, 1), false)
+                .add(Items.DIRT.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
+                .add(Items.COARSE_DIRT.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
+                .add(Items.MUD.builtInRegistryHolder(), new EssenceValue(earth, 1, water, 1), false)
+                .add(Items.PACKED_MUD.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
+                .add(Items.GRAVEL.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
+                .add(Items.SUSPICIOUS_GRAVEL.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
+                .add(Items.CLAY_BALL.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
+                .add(Items.CLAY.builtInRegistryHolder(), new EssenceValue(earth, 1), false);
+
+        // Stone
+        this.builder(ModDataMaps.ESSENCE_VALUE_DATA)
+                .add(Items.FLINT.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
+                .add(Tags.Items.STONES, new EssenceValue(earth, 1), false)
+                .add(Items.STONE_SLAB.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
+                .add(Items.STONE_STAIRS.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
+
+                .add(Items.ANDESITE_SLAB.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
+                .add(Items.ANDESITE_STAIRS.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
+                .add(Items.ANDESITE_WALL.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
+                .add(Items.BLACKSTONE.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
+                .add(Items.BLACKSTONE_SLAB.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
+                .add(Items.BLACKSTONE_STAIRS.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
+                .add(Items.BLACKSTONE_WALL.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
+                .add(Items.GILDED_BLACKSTONE.builtInRegistryHolder(), new EssenceValue(earth, 1, metal, 1), false)
+                .add(Items.DIORITE_SLAB.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
+                .add(Items.DIORITE_STAIRS.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
+                .add(Items.DIORITE_WALL.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
+                .add(Items.GRANITE_SLAB.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
+                .add(Items.GRANITE_STAIRS.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
+                .add(Items.GRANITE_WALL.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
+                .add(Items.TUFF_SLAB.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
+                .add(Items.TUFF_STAIRS.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
+                .add(Items.TUFF_WALL.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
+
+                .add(Tags.Items.COBBLESTONES_NORMAL, new EssenceValue(earth, 1), false)
+                .add(Items.COBBLESTONE_SLAB.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
+                .add(Items.COBBLESTONE_STAIRS.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
+                .add(Items.COBBLESTONE_WALL.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
+
+                .add(Tags.Items.COBBLESTONES_MOSSY, new EssenceValue(earth, 1, plant, 1), false)
+                .add(Items.MOSSY_COBBLESTONE_SLAB.builtInRegistryHolder(), new EssenceValue(earth, 1, plant, 1), false)
+                .add(Items.MOSSY_COBBLESTONE_STAIRS.builtInRegistryHolder(), new EssenceValue(earth, 1, plant, 1), false)
+                .add(Items.MOSSY_COBBLESTONE_WALL.builtInRegistryHolder(), new EssenceValue(earth, 1, plant, 1), false)
+
+                .add(Tags.Items.COBBLESTONES_DEEPSLATE, new EssenceValue(earth, 1), false)
+                .add(Items.COBBLED_DEEPSLATE_SLAB.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
+                .add(Items.COBBLED_DEEPSLATE_STAIRS.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
+                .add(Items.COBBLED_DEEPSLATE_WALL.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
+
+                .add(Items.SMOOTH_STONE.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
+                .add(Items.SMOOTH_STONE_SLAB.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
+
+                .add(Items.CHISELED_DEEPSLATE.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
+
+                .add(Items.CALCITE.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
+                .add(Items.POINTED_DRIPSTONE.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
+                .add(Items.DRIPSTONE_BLOCK.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
+
+                .add(Items.BASALT.builtInRegistryHolder(), new EssenceValue(earth, 1, fire, 1), false)
+                .add(Items.SMOOTH_BASALT.builtInRegistryHolder(), new EssenceValue(earth, 1, fire, 1), false)
+                .add(Items.POLISHED_BASALT.builtInRegistryHolder(), new EssenceValue(earth, 1, fire, 1), false)
+
+
+                .add(Items.POLISHED_ANDESITE.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
+                .add(Items.POLISHED_ANDESITE_SLAB.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
+                .add(Items.POLISHED_ANDESITE_STAIRS.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
+                .add(Items.POLISHED_BLACKSTONE.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
+                .add(Items.POLISHED_BLACKSTONE_SLAB.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
+                .add(Items.POLISHED_BLACKSTONE_STAIRS.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
+                .add(Items.POLISHED_BLACKSTONE_WALL.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
+                .add(Items.CHISELED_POLISHED_BLACKSTONE.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
+                .add(Items.POLISHED_DIORITE.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
+                .add(Items.POLISHED_DIORITE_SLAB.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
+                .add(Items.POLISHED_DIORITE_STAIRS.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
+                .add(Items.POLISHED_GRANITE.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
+                .add(Items.POLISHED_GRANITE_SLAB.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
+                .add(Items.POLISHED_GRANITE_STAIRS.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
+                .add(Items.POLISHED_DEEPSLATE.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
+                .add(Items.POLISHED_DEEPSLATE_SLAB.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
+                .add(Items.POLISHED_DEEPSLATE_STAIRS.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
+                .add(Items.POLISHED_DEEPSLATE_WALL.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
+                .add(Items.POLISHED_TUFF.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
+                .add(Items.POLISHED_TUFF_SLAB.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
+                .add(Items.POLISHED_TUFF_STAIRS.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
+                .add(Items.POLISHED_TUFF_WALL.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
+                .add(Items.CHISELED_TUFF.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
+
+                .add(Items.OBSIDIAN.builtInRegistryHolder(), new EssenceValue(earth, 1, fire, 1), false)
+                .add(Items.CRYING_OBSIDIAN.builtInRegistryHolder(), new EssenceValue(earth, 1, fire, 1), false)
+                .add(Items.MAGMA_BLOCK.builtInRegistryHolder(), new EssenceValue(earth, 1, fire, 1), false)
+
+                .add(Tags.Items.SANDSTONE_BLOCKS, new EssenceValue(earth, 1), false)
+                .add(Tags.Items.SANDSTONE_SLABS, new EssenceValue(earth, 1), false)
+                .add(Tags.Items.SANDSTONE_STAIRS, new EssenceValue(earth, 1), false)
+                .add(Items.SANDSTONE_WALL.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
+                .add(Items.RED_SANDSTONE_WALL.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
+                .add(ItemTags.TERRACOTTA, new EssenceValue(earth, 1), false)
+                .add(Tags.Items.GLAZED_TERRACOTTAS, new EssenceValue(earth, 1), false)
+                .add(Tags.Items.CONCRETES, new EssenceValue(earth, 1), false)
+                .add(Tags.Items.CONCRETE_POWDERS, new EssenceValue(earth, 1), false);
+
+        // Bricks
+        this.builder(ModDataMaps.ESSENCE_VALUE_DATA)
+                .add(Tags.Items.BRICKS_NORMAL, new EssenceValue(earth, 1), false)
+                .add(Items.BRICKS.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
+                .add(Items.BRICK_SLAB.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
+                .add(Items.BRICK_STAIRS.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
+                .add(Items.BRICK_WALL.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
+                .add(Items.MUD_BRICKS.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
+                .add(Items.MUD_BRICK_SLAB.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
+                .add(Items.MUD_BRICK_STAIRS.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
+                .add(Items.MUD_BRICK_WALL.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
+                .add(Items.DEEPSLATE_BRICKS.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
+                .add(Items.DEEPSLATE_BRICK_SLAB.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
+                .add(Items.DEEPSLATE_BRICK_STAIRS.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
+                .add(Items.DEEPSLATE_BRICK_WALL.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
+                .add(Items.CRACKED_DEEPSLATE_BRICKS.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
+                .add(Items.DEEPSLATE_TILES.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
+                .add(Items.DEEPSLATE_TILE_SLAB.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
+                .add(Items.DEEPSLATE_TILE_STAIRS.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
+                .add(Items.DEEPSLATE_TILE_WALL.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
+                .add(Items.CRACKED_DEEPSLATE_TILES.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
+                .add(ItemTags.STONE_BRICKS, new EssenceValue(earth, 1), false)
+                .add(Items.STONE_BRICK_SLAB.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
+                .add(Items.STONE_BRICK_STAIRS.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
+                .add(Items.STONE_BRICK_WALL.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
+                .add(Items.MOSSY_STONE_BRICKS.builtInRegistryHolder(), new EssenceValue(earth, 1, plant, 1), false)
+                .add(Items.MOSSY_STONE_BRICK_SLAB.builtInRegistryHolder(), new EssenceValue(earth, 1, plant, 1), false)
+                .add(Items.MOSSY_STONE_BRICK_STAIRS.builtInRegistryHolder(), new EssenceValue(earth, 1, plant, 1), false)
+                .add(Items.MOSSY_STONE_BRICK_WALL.builtInRegistryHolder(), new EssenceValue(earth, 1, plant, 1), false)
+                .add(Items.TUFF_BRICKS.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
+                .add(Items.TUFF_BRICK_SLAB.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
+                .add(Items.TUFF_BRICK_STAIRS.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
+                .add(Items.TUFF_BRICK_WALL.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
+                .add(Items.CHISELED_TUFF_BRICKS.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
+                .add(Items.POLISHED_BLACKSTONE_BRICKS.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
+                .add(Items.POLISHED_BLACKSTONE_BRICK_SLAB.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
+                .add(Items.POLISHED_BLACKSTONE_BRICK_STAIRS.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
+                .add(Items.POLISHED_BLACKSTONE_BRICK_WALL.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
+                .add(Items.CRACKED_POLISHED_BLACKSTONE_BRICKS.builtInRegistryHolder(), new EssenceValue(earth, 1), false);
+
+        // Nether Stone
+        this.builder(ModDataMaps.ESSENCE_VALUE_DATA)
+                .add(Items.NETHERRACK.builtInRegistryHolder(), new EssenceValue(earth, 1, nether, 1), false)
+                .add(Tags.Items.BRICKS_NETHER, new EssenceValue(nether, 1, earth, 1), false)
+                .add(Items.NETHER_BRICKS.builtInRegistryHolder(), new EssenceValue(nether, 1, earth, 1), false)
+                .add(Items.CRACKED_NETHER_BRICKS.builtInRegistryHolder(), new EssenceValue(nether, 1, earth, 1), false)
+                .add(Items.NETHER_BRICK_SLAB.builtInRegistryHolder(), new EssenceValue(earth, 1, nether, 1), false)
+                .add(Items.NETHER_BRICK_STAIRS.builtInRegistryHolder(), new EssenceValue(earth, 1, nether, 1), false)
+                .add(Items.NETHER_BRICK_WALL.builtInRegistryHolder(), new EssenceValue(earth, 1, nether, 1), false)
+                .add(Items.CHISELED_NETHER_BRICKS.builtInRegistryHolder(), new EssenceValue(nether, 1, earth, 1), false)
+                .add(Items.RED_NETHER_BRICKS.builtInRegistryHolder(), new EssenceValue(nether, 1, earth, 1), false)
+                .add(Items.RED_NETHER_BRICK_SLAB.builtInRegistryHolder(), new EssenceValue(nether, 1, earth, 1), false)
+                .add(Items.RED_NETHER_BRICK_STAIRS.builtInRegistryHolder(), new EssenceValue(nether, 1, earth, 1), false)
+                .add(Items.RED_NETHER_BRICK_WALL.builtInRegistryHolder(), new EssenceValue(nether, 1, earth, 1), false)
+                .add(Items.SOUL_SAND.builtInRegistryHolder(), new EssenceValue(earth, 1, nether, 1), false)
+                .add(Items.SOUL_SOIL.builtInRegistryHolder(), new EssenceValue(earth, 1, nether, 1), false);
+
+        // End Stone
+        this.builder(ModDataMaps.ESSENCE_VALUE_DATA)
+                .add(Items.PURPUR_BLOCK.builtInRegistryHolder(), new EssenceValue(earth, 1, end, 1), false)
+                .add(Items.PURPUR_PILLAR.builtInRegistryHolder(), new EssenceValue(earth, 1, end, 1), false)
+                .add(Items.PURPUR_SLAB.builtInRegistryHolder(), new EssenceValue(earth, 1, end, 1), false)
+                .add(Items.PURPUR_STAIRS.builtInRegistryHolder(), new EssenceValue(earth, 1, end, 1), false)
+                .add(Items.END_STONE.builtInRegistryHolder(), new EssenceValue(earth, 1, end, 1), false)
+                .add(Items.END_STONE_BRICKS.builtInRegistryHolder(), new EssenceValue(earth, 1, end, 1), false)
+                .add(Items.END_STONE_BRICK_SLAB.builtInRegistryHolder(), new EssenceValue(earth, 1, end, 1), false)
+                .add(Items.END_STONE_BRICK_STAIRS.builtInRegistryHolder(), new EssenceValue(earth, 1, end, 1), false)
+                .add(Items.END_STONE_BRICK_WALL.builtInRegistryHolder(), new EssenceValue(earth, 1, end, 1), false);
+
+        // Glass
+        this.builder(ModDataMaps.ESSENCE_VALUE_DATA)
+                .add(Tags.Items.GLASS_BLOCKS_CHEAP, new EssenceValue(earth, 1, crystal, 1), false)
+                .add(Tags.Items.GLASS_PANES, new EssenceValue(earth, 1, crystal, 1), false)
+                .add(Items.TINTED_GLASS.builtInRegistryHolder(), new EssenceValue(earth, 1, crystal, 1), false)
+                .add(Items.GLASS_BOTTLE.builtInRegistryHolder(), new EssenceValue(earth, 1, crystal, 1), false);
+
+        // Ores
+        this.builder(ModDataMaps.ESSENCE_VALUE_DATA)
+                .add(ItemTags.COAL_ORES, new EssenceValue(earth, 1, fire, 1), false)
+                .add(Items.COAL.builtInRegistryHolder(), new EssenceValue(earth, 1, fire, 1), false)
+                .add(Items.CHARCOAL.builtInRegistryHolder(), new EssenceValue(earth, 1, fire, 1), false)
+                .add(Items.COAL_BLOCK.builtInRegistryHolder(), new EssenceValue(earth, 1, fire, 1), false)
+                .add(ItemTags.COPPER_ORES, new EssenceValue(earth, 1, metal, 1), false)
+                .add(Items.GOLD_ORE.builtInRegistryHolder(), new EssenceValue(earth, 1, metal, 1), false)
+                .add(Items.DEEPSLATE_GOLD_ORE.builtInRegistryHolder(), new EssenceValue(earth, 1, metal, 1), false)
+                .add(Items.NETHER_GOLD_ORE.builtInRegistryHolder(), new EssenceValue(nether, 1, metal, 1), false)
+                .add(ItemTags.DIAMOND_ORES, new EssenceValue(earth, 1, crystal, 1), false)
+                .add(ItemTags.EMERALD_ORES, new EssenceValue(earth, 1, crystal, 1), false)
+                .add(ItemTags.IRON_ORES, new EssenceValue(earth, 1, metal, 1), false)
+                .add(ItemTags.LAPIS_ORES, new EssenceValue(earth, 1, crystal, 1), false)
+                .add(Tags.Items.ORES_QUARTZ, new EssenceValue(nether, 1, crystal, 1), false)
+                .add(Tags.Items.ORES_REDSTONE, new EssenceValue(earth, 1, power, 1), false)
+                .add(Items.ANCIENT_DEBRIS.builtInRegistryHolder(), new EssenceValue(nether, 1, metal, 1), false);
+
+        // Copper
+        this.builder(ModDataMaps.ESSENCE_VALUE_DATA)
+                .add(Items.RAW_COPPER.builtInRegistryHolder(), new EssenceValue(metal, 1), false)
+                .add(Items.RAW_COPPER_BLOCK.builtInRegistryHolder(), new EssenceValue(metal, 1), false)
+                .add(Tags.Items.INGOTS_COPPER, new EssenceValue(metal, 1), false)
+                .add(Items.COPPER_BLOCK.builtInRegistryHolder(), new EssenceValue(metal, 1), false)
+                .add(Items.EXPOSED_COPPER.builtInRegistryHolder(), new EssenceValue(metal, 1), false)
+                .add(Items.WEATHERED_COPPER.builtInRegistryHolder(), new EssenceValue(metal, 1), false)
+                .add(Items.OXIDIZED_COPPER.builtInRegistryHolder(), new EssenceValue(metal, 1), false)
+                .add(Items.CHISELED_COPPER.builtInRegistryHolder(), new EssenceValue(metal, 1), false)
+                .add(Items.EXPOSED_CHISELED_COPPER.builtInRegistryHolder(), new EssenceValue(metal, 1), false)
+                .add(Items.WEATHERED_CHISELED_COPPER.builtInRegistryHolder(), new EssenceValue(metal, 1), false)
+                .add(Items.OXIDIZED_CHISELED_COPPER.builtInRegistryHolder(), new EssenceValue(metal, 1), false)
+                .add(Items.CUT_COPPER.builtInRegistryHolder(), new EssenceValue(metal, 1), false)
+                .add(Items.EXPOSED_CUT_COPPER.builtInRegistryHolder(), new EssenceValue(metal, 1), false)
+                .add(Items.WEATHERED_CUT_COPPER.builtInRegistryHolder(), new EssenceValue(metal, 1), false)
+                .add(Items.OXIDIZED_CUT_COPPER.builtInRegistryHolder(), new EssenceValue(metal, 1), false)
+                .add(Items.CUT_COPPER_SLAB.builtInRegistryHolder(), new EssenceValue(metal, 1), false)
+                .add(Items.EXPOSED_CUT_COPPER_SLAB.builtInRegistryHolder(), new EssenceValue(metal, 1), false)
+                .add(Items.WEATHERED_CUT_COPPER_SLAB.builtInRegistryHolder(), new EssenceValue(metal, 1), false)
+                .add(Items.OXIDIZED_CUT_COPPER_SLAB.builtInRegistryHolder(), new EssenceValue(metal, 1), false)
+                .add(Items.CUT_COPPER_STAIRS.builtInRegistryHolder(), new EssenceValue(metal, 1), false)
+                .add(Items.EXPOSED_CUT_COPPER_STAIRS.builtInRegistryHolder(), new EssenceValue(metal, 1), false)
+                .add(Items.WEATHERED_CUT_COPPER_STAIRS.builtInRegistryHolder(), new EssenceValue(metal, 1), false)
+                .add(Items.OXIDIZED_CUT_COPPER_STAIRS.builtInRegistryHolder(), new EssenceValue(metal, 1), false)
+
+                .add(Items.WAXED_COPPER_BLOCK.builtInRegistryHolder(), new EssenceValue(metal, 1), false)
+                .add(Items.WAXED_EXPOSED_COPPER.builtInRegistryHolder(), new EssenceValue(metal, 1), false)
+                .add(Items.WAXED_WEATHERED_COPPER.builtInRegistryHolder(), new EssenceValue(metal, 1), false)
+                .add(Items.WAXED_OXIDIZED_COPPER.builtInRegistryHolder(), new EssenceValue(metal, 1), false)
+                .add(Items.WAXED_CHISELED_COPPER.builtInRegistryHolder(), new EssenceValue(metal, 1), false)
+                .add(Items.WAXED_EXPOSED_CHISELED_COPPER.builtInRegistryHolder(), new EssenceValue(metal, 1), false)
+                .add(Items.WAXED_WEATHERED_CHISELED_COPPER.builtInRegistryHolder(), new EssenceValue(metal, 1), false)
+                .add(Items.WAXED_OXIDIZED_CHISELED_COPPER.builtInRegistryHolder(), new EssenceValue(metal, 1), false)
+                .add(Items.WAXED_CUT_COPPER.builtInRegistryHolder(), new EssenceValue(metal, 1), false)
+                .add(Items.WAXED_EXPOSED_CUT_COPPER.builtInRegistryHolder(), new EssenceValue(metal, 1), false)
+                .add(Items.WAXED_WEATHERED_CUT_COPPER.builtInRegistryHolder(), new EssenceValue(metal, 1), false)
+                .add(Items.WAXED_OXIDIZED_CUT_COPPER.builtInRegistryHolder(), new EssenceValue(metal, 1), false)
+                .add(Items.WAXED_CUT_COPPER_SLAB.builtInRegistryHolder(), new EssenceValue(metal, 1), false)
+                .add(Items.WAXED_EXPOSED_CUT_COPPER_SLAB.builtInRegistryHolder(), new EssenceValue(metal, 1), false)
+                .add(Items.WAXED_WEATHERED_CUT_COPPER_SLAB.builtInRegistryHolder(), new EssenceValue(metal, 1), false)
+                .add(Items.WAXED_OXIDIZED_CUT_COPPER_SLAB.builtInRegistryHolder(), new EssenceValue(metal, 1), false)
+                .add(Items.WAXED_CUT_COPPER_STAIRS.builtInRegistryHolder(), new EssenceValue(metal, 1), false)
+                .add(Items.WAXED_EXPOSED_CUT_COPPER_STAIRS.builtInRegistryHolder(), new EssenceValue(metal, 1), false)
+                .add(Items.WAXED_WEATHERED_CUT_COPPER_STAIRS.builtInRegistryHolder(), new EssenceValue(metal, 1), false)
+                .add(Items.WAXED_OXIDIZED_CUT_COPPER_STAIRS.builtInRegistryHolder(), new EssenceValue(metal, 1), false);
+
+        // Metals
+        this.builder(ModDataMaps.ESSENCE_VALUE_DATA)
+                .add(Items.IRON_NUGGET.builtInRegistryHolder(), new EssenceValue(metal, 1), false)
+                .add(Items.RAW_IRON_BLOCK.builtInRegistryHolder(), new EssenceValue(metal, 1), false)
+                .add(Items.RAW_IRON.builtInRegistryHolder(), new EssenceValue(metal, 1), false)
+                .add(Tags.Items.INGOTS_IRON, new EssenceValue(metal, 1), false)
+                .add(Items.IRON_BLOCK.builtInRegistryHolder(), new EssenceValue(metal, 1), false)
+                .add(Items.GOLD_NUGGET.builtInRegistryHolder(), new EssenceValue(metal, 1), false)
+                .add(Items.RAW_GOLD_BLOCK.builtInRegistryHolder(), new EssenceValue(metal, 1), false)
+                .add(Items.RAW_GOLD.builtInRegistryHolder(), new EssenceValue(metal, 1), false)
+                .add(Tags.Items.INGOTS_GOLD, new EssenceValue(metal, 1), false)
+                .add(Items.GOLD_BLOCK.builtInRegistryHolder(), new EssenceValue(metal, 1), false)
+                .add(Items.NETHERITE_SCRAP.builtInRegistryHolder(), new EssenceValue(metal, 1, nether, 1), false)
+                .add(Tags.Items.INGOTS_NETHERITE, new EssenceValue(metal, 1, nether, 1), false)
+                .add(Items.NETHERITE_BLOCK.builtInRegistryHolder(), new EssenceValue(metal, 1, nether, 1), false);
+
+        // Gems
+        this.builder(ModDataMaps.ESSENCE_VALUE_DATA)
+                .add(Items.AMETHYST_CLUSTER.builtInRegistryHolder(), new EssenceValue(crystal, 1), false)
+                .add(Items.AMETHYST_SHARD.builtInRegistryHolder(), new EssenceValue(crystal, 1), false)
+                .add(Items.AMETHYST_BLOCK.builtInRegistryHolder(), new EssenceValue(crystal, 1), false)
+                .add(Items.SMALL_AMETHYST_BUD.builtInRegistryHolder(), new EssenceValue(crystal, 1), false)
+                .add(Items.MEDIUM_AMETHYST_BUD.builtInRegistryHolder(), new EssenceValue(crystal, 1), false)
+                .add(Items.LARGE_AMETHYST_BUD.builtInRegistryHolder(), new EssenceValue(crystal, 1), false)
+                .add(Items.DIAMOND.builtInRegistryHolder(), new EssenceValue(crystal, 1), false)
+                .add(Items.DIAMOND_BLOCK.builtInRegistryHolder(), new EssenceValue(crystal, 1), false)
+                .add(Items.EMERALD.builtInRegistryHolder(), new EssenceValue(crystal, 1), false)
+                .add(Items.EMERALD_BLOCK.builtInRegistryHolder(), new EssenceValue(crystal, 1), false)
+                .add(Items.LAPIS_LAZULI.builtInRegistryHolder(), new EssenceValue(crystal, 1), false)
+                .add(Items.LAPIS_BLOCK.builtInRegistryHolder(), new EssenceValue(crystal, 1), false)
+                .add(Items.QUARTZ.builtInRegistryHolder(), new EssenceValue(crystal, 1, nether, 1), false)
+                .add(Items.QUARTZ_BLOCK.builtInRegistryHolder(), new EssenceValue(crystal, 1, nether, 1), false)
+                .add(Items.CHISELED_QUARTZ_BLOCK.builtInRegistryHolder(), new EssenceValue(crystal, 1, nether, 1), false)
+                .add(Items.QUARTZ_BRICKS.builtInRegistryHolder(), new EssenceValue(crystal, 1, nether, 1), false)
+                .add(Items.QUARTZ_SLAB.builtInRegistryHolder(), new EssenceValue(crystal, 1, nether, 1), false)
+                .add(Items.QUARTZ_PILLAR.builtInRegistryHolder(), new EssenceValue(crystal, 1, nether, 1), false)
+                .add(Items.QUARTZ_STAIRS.builtInRegistryHolder(), new EssenceValue(crystal, 1, nether, 1), false)
+                .add(Items.SMOOTH_QUARTZ.builtInRegistryHolder(), new EssenceValue(crystal, 1, nether, 1), false)
+                .add(Items.SMOOTH_QUARTZ_SLAB.builtInRegistryHolder(), new EssenceValue(crystal, 1, nether, 1), false)
+                .add(Items.SMOOTH_QUARTZ_STAIRS.builtInRegistryHolder(), new EssenceValue(crystal, 1, nether, 1), false)
+                .add(Items.ECHO_SHARD.builtInRegistryHolder(), new EssenceValue(crystal, 1, dark, 1), false)
+
+                .add(Items.PRISMARINE_SHARD.builtInRegistryHolder(), new EssenceValue(crystal, 1, water, 1), false)
+                .add(Items.PRISMARINE.builtInRegistryHolder(), new EssenceValue(crystal, 1, water, 1), false)
+                .add(Items.PRISMARINE_CRYSTALS.builtInRegistryHolder(), new EssenceValue(crystal, 1, water, 1), false)
+                .add(Items.DARK_PRISMARINE.builtInRegistryHolder(), new EssenceValue(crystal, 1, water, 1), false)
+                .add(Items.DARK_PRISMARINE_SLAB.builtInRegistryHolder(), new EssenceValue(crystal, 1, water, 1), false)
+                .add(Items.DARK_PRISMARINE_STAIRS.builtInRegistryHolder(),
+                        new EssenceValue(crystal, 1, water, 1, order, 1), false)
+                .add(Items.DARK_PRISMARINE.builtInRegistryHolder(), new EssenceValue(crystal, 1, water, 1), false)
+                .add(Items.PRISMARINE_SLAB.builtInRegistryHolder(), new EssenceValue(crystal, 1, water, 1), false)
+                .add(Items.PRISMARINE_BRICK_SLAB.builtInRegistryHolder(),
+                        new EssenceValue(crystal, 1, water, 1, order, 1), false)
+                .add(Items.PRISMARINE_BRICKS.builtInRegistryHolder(), new EssenceValue(crystal, 1, water, 1, order, 1),
+                        false)
+                .add(Items.PRISMARINE_BRICK_STAIRS.builtInRegistryHolder(),
+                        new EssenceValue(crystal, 1, water, 1, order, 1), false)
+                .add(Items.PRISMARINE_STAIRS.builtInRegistryHolder(), new EssenceValue(crystal, 1, water, 1, order, 1),
+                        false)
+                .add(Items.PRISMARINE_WALL.builtInRegistryHolder(), new EssenceValue(crystal, 1, water, 1, order, 1),
+                        false)
+                .add(Items.NETHER_STAR.builtInRegistryHolder(), new EssenceValue(crystal, 1, nether, 1), false);
+
+        // Stone Structues
+        this.builder(ModDataMaps.ESSENCE_VALUE_DATA)
+                .add(Tags.Items.FENCES_NETHER_BRICK, new EssenceValue(nether, 1, earth, 1), false)
+                .add(ItemTags.STONE_BUTTONS, new EssenceValue(earth, 1), false)
+                .add(Items.STONE_PRESSURE_PLATE.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
+                .add(Items.LIGHT_WEIGHTED_PRESSURE_PLATE.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
+                .add(Items.HEAVY_WEIGHTED_PRESSURE_PLATE.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
+                .add(Items.POLISHED_BLACKSTONE_PRESSURE_PLATE.builtInRegistryHolder(), new EssenceValue(earth, 1), false);
+
+        // Wooden Structures
+        this.builder(ModDataMaps.ESSENCE_VALUE_DATA)
+                .add(Tags.Items.FENCE_GATES_WOODEN, new EssenceValue(plant, 1, order, 1), false)
+                .add(Items.PALE_OAK_FENCE_GATE.builtInRegistryHolder(), new EssenceValue(plant, 1, order, 1), false)
+                .add(ItemTags.SIGNS, new EssenceValue(plant, 1, order, 1), false)
+                .add(ItemTags.HANGING_SIGNS, new EssenceValue(plant, 1, order, 1), false)
+                .add(ItemTags.WOODEN_BUTTONS, new EssenceValue(plant, 1, order, 1), false)
+                .add(ItemTags.WOODEN_DOORS, new EssenceValue(plant, 1, order, 1), false)
+                .add(ItemTags.WOODEN_FENCES, new EssenceValue(plant, 1, order, 1), false)
+                .add(ItemTags.WOODEN_PRESSURE_PLATES, new EssenceValue(plant, 1, order, 1), false)
+                .add(ItemTags.WOODEN_TRAPDOORS, new EssenceValue(plant, 1, order, 1), false)
+                .add(Tags.Items.BARRELS_WOODEN, new EssenceValue(plant, 1, order, 1), false)
+                .add(Tags.Items.CHESTS_WOODEN, new EssenceValue(plant, 1, order, 1), false)
+                .add(Items.LECTERN.builtInRegistryHolder(), new EssenceValue(plant, 1), false)
+                .add(Items.LADDER.builtInRegistryHolder(), new EssenceValue(plant, 1), false)
+                .add(Items.SCAFFOLDING.builtInRegistryHolder(), new EssenceValue(plant, 1), false)
+                .add(Items.TARGET.builtInRegistryHolder(), new EssenceValue(plant, 1), false);
+
+        // Metal Structures
+        this.builder(ModDataMaps.ESSENCE_VALUE_DATA)
+                .add(Items.COPPER_DOOR.builtInRegistryHolder(), new EssenceValue(metal, 1, order, 1), false)
+                .add(Items.EXPOSED_COPPER_DOOR.builtInRegistryHolder(), new EssenceValue(metal, 1, order, 1), false)
+                .add(Items.WEATHERED_COPPER_DOOR.builtInRegistryHolder(), new EssenceValue(metal, 1, order, 1), false)
+                .add(Items.OXIDIZED_COPPER_DOOR.builtInRegistryHolder(), new EssenceValue(metal, 1, order, 1), false)
+                .add(Items.COPPER_TRAPDOOR.builtInRegistryHolder(), new EssenceValue(metal, 1, order, 1), false)
+                .add(Items.EXPOSED_COPPER_TRAPDOOR.builtInRegistryHolder(), new EssenceValue(metal, 1, order, 1), false)
+                .add(Items.WEATHERED_COPPER_TRAPDOOR.builtInRegistryHolder(), new EssenceValue(metal, 1, order, 1),
+                        false)
+                .add(Items.OXIDIZED_COPPER_TRAPDOOR.builtInRegistryHolder(), new EssenceValue(metal, 1, order, 1),
+                        false)
+                .add(Items.COPPER_GRATE.builtInRegistryHolder(), new EssenceValue(metal, 1, order, 1), false)
+                .add(Items.EXPOSED_COPPER_GRATE.builtInRegistryHolder(), new EssenceValue(metal, 1, order, 1), false)
+                .add(Items.WEATHERED_COPPER_GRATE.builtInRegistryHolder(), new EssenceValue(metal, 1, order, 1), false)
+                .add(Items.OXIDIZED_COPPER_GRATE.builtInRegistryHolder(), new EssenceValue(metal, 1, order, 1), false)
+                .add(Items.WAXED_COPPER_DOOR.builtInRegistryHolder(), new EssenceValue(metal, 1, order, 1), false)
+                .add(Items.WAXED_EXPOSED_COPPER_DOOR.builtInRegistryHolder(), new EssenceValue(metal, 1, order, 1),
+                        false)
+                .add(Items.WAXED_WEATHERED_COPPER_DOOR.builtInRegistryHolder(), new EssenceValue(metal, 1, order, 1),
+                        false)
+                .add(Items.WAXED_OXIDIZED_COPPER_DOOR.builtInRegistryHolder(), new EssenceValue(metal, 1, order, 1),
+                        false)
+                .add(Items.WAXED_COPPER_TRAPDOOR.builtInRegistryHolder(), new EssenceValue(metal, 1, order, 1), false)
+                .add(Items.WAXED_EXPOSED_COPPER_TRAPDOOR.builtInRegistryHolder(), new EssenceValue(metal, 1, order, 1),
+                        false)
+                .add(Items.WAXED_WEATHERED_COPPER_TRAPDOOR.builtInRegistryHolder(),
+                        new EssenceValue(metal, 1, order, 1), false)
+                .add(Items.WAXED_OXIDIZED_COPPER_TRAPDOOR.builtInRegistryHolder(), new EssenceValue(metal, 1, order, 1),
+                        false)
+                .add(Items.WAXED_COPPER_GRATE.builtInRegistryHolder(), new EssenceValue(metal, 1, order, 1), false)
+                .add(Items.WAXED_EXPOSED_COPPER_GRATE.builtInRegistryHolder(), new EssenceValue(metal, 1, order, 1),
+                        false)
+                .add(Items.WAXED_WEATHERED_COPPER_GRATE.builtInRegistryHolder(), new EssenceValue(metal, 1, order, 1),
+                        false)
+                .add(Items.WAXED_OXIDIZED_COPPER_GRATE.builtInRegistryHolder(), new EssenceValue(metal, 1, order, 1),
+                        false)
+
+                .add(Items.IRON_DOOR.builtInRegistryHolder(), new EssenceValue(metal, 1, order, 1), false)
+                .add(Items.IRON_TRAPDOOR.builtInRegistryHolder(), new EssenceValue(metal, 1, order, 1), false)
+                .add(Items.RAIL.builtInRegistryHolder(), new EssenceValue(metal, 1, order, 1), false)
+                .add(Items.IRON_BARS.builtInRegistryHolder(), new EssenceValue(metal, 1), false)
+                .add(Items.CHAIN.builtInRegistryHolder(), new EssenceValue(metal, 1), false);
+
+        // Redstone
+        this.builder(ModDataMaps.ESSENCE_VALUE_DATA)
+                .add(Items.REDSTONE.builtInRegistryHolder(), new EssenceValue(power, 1), false)
+                .add(Items.REDSTONE_BLOCK.builtInRegistryHolder(), new EssenceValue(power, 1), false)
+                .add(Items.ACTIVATOR_RAIL.builtInRegistryHolder(), new EssenceValue(power, 1, order, 1), false)
+                .add(Items.DETECTOR_RAIL.builtInRegistryHolder(), new EssenceValue(power, 1, order, 1), false)
+                .add(Items.POWERED_RAIL.builtInRegistryHolder(), new EssenceValue(power, 1, order, 1), false)
+                .add(Items.NOTE_BLOCK.builtInRegistryHolder(), new EssenceValue(power, 1, order, 1), false);
+
+        // Knowledge
+        this.builder(ModDataMaps.ESSENCE_VALUE_DATA)
+                .add(Tags.Items.POTIONS, new EssenceValue(water, 1, knowledge, 1), false)
+                .add(Items.BOOKSHELF.builtInRegistryHolder(), new EssenceValue(order, 1, knowledge, 1), false)
+                .add(Items.CHISELED_BOOKSHELF.builtInRegistryHolder(), new EssenceValue(order, 1, knowledge, 1), false)
+                .add(Items.ENCHANTING_TABLE.builtInRegistryHolder(), new EssenceValue(knowledge, 1), false)
+                .add(Items.ENCHANTED_GOLDEN_APPLE.builtInRegistryHolder(), new EssenceValue(plant, 1, knowledge, 1), false)
+                .add(Items.BEACON.builtInRegistryHolder(), new EssenceValue(knowledge, 1, crystal, 1), false)
+                .add(Items.CONDUIT.builtInRegistryHolder(), new EssenceValue(knowledge, 1, water, 1), false)
+                .add(Items.HEART_OF_THE_SEA.builtInRegistryHolder(), new EssenceValue(water, 1, crystal, 1), false)
+                .add(Items.END_CRYSTAL.builtInRegistryHolder(), new EssenceValue(end, 1, crystal, 1), false)
+
+                .add(Items.PAPER.builtInRegistryHolder(), new EssenceValue(knowledge, 1), false)
+                .add(Items.BOOK.builtInRegistryHolder(), new EssenceValue(knowledge, 1), false)
+                .add(Items.WRITABLE_BOOK.builtInRegistryHolder(), new EssenceValue(knowledge, 1), false)
+                .add(Items.WRITTEN_BOOK.builtInRegistryHolder(), new EssenceValue(knowledge, 1), false)
+                .add(Items.ENCHANTED_BOOK.builtInRegistryHolder(), new EssenceValue(knowledge, 1), false)
+                .add(Items.MAP.builtInRegistryHolder(), new EssenceValue(knowledge, 1), false)
+                .add(Items.FILLED_MAP.builtInRegistryHolder(), new EssenceValue(knowledge, 1, space, 1), false)
+                .add(Items.EXPERIENCE_BOTTLE.builtInRegistryHolder(), new EssenceValue(knowledge, 1), false)
+                .add(Items.FIRE_CHARGE.builtInRegistryHolder(), new EssenceValue(fire, 1), false)
+                .add(Items.WIND_CHARGE.builtInRegistryHolder(), new EssenceValue(air, 1), false)
+                .add(Items.DRAGON_BREATH.builtInRegistryHolder(), new EssenceValue(end, 1), false)
+
+                .add(Items.NETHERITE_UPGRADE_SMITHING_TEMPLATE.builtInRegistryHolder(), new EssenceValue(knowledge, 1), false)
+                .add(Items.SENTRY_ARMOR_TRIM_SMITHING_TEMPLATE.builtInRegistryHolder(), new EssenceValue(knowledge, 1), false)
+                .add(Items.DUNE_ARMOR_TRIM_SMITHING_TEMPLATE.builtInRegistryHolder(), new EssenceValue(knowledge, 1), false)
+                .add(Items.COAST_ARMOR_TRIM_SMITHING_TEMPLATE.builtInRegistryHolder(), new EssenceValue(knowledge, 1), false)
+                .add(Items.WILD_ARMOR_TRIM_SMITHING_TEMPLATE.builtInRegistryHolder(), new EssenceValue(knowledge, 1), false)
+                .add(Items.WARD_ARMOR_TRIM_SMITHING_TEMPLATE.builtInRegistryHolder(), new EssenceValue(knowledge, 1), false)
+                .add(Items.EYE_ARMOR_TRIM_SMITHING_TEMPLATE.builtInRegistryHolder(), new EssenceValue(knowledge, 1), false)
+                .add(Items.VEX_ARMOR_TRIM_SMITHING_TEMPLATE.builtInRegistryHolder(), new EssenceValue(knowledge, 1), false)
+                .add(Items.TIDE_ARMOR_TRIM_SMITHING_TEMPLATE.builtInRegistryHolder(), new EssenceValue(knowledge, 1), false)
+                .add(Items.SNOUT_ARMOR_TRIM_SMITHING_TEMPLATE.builtInRegistryHolder(), new EssenceValue(knowledge, 1), false)
+                .add(Items.RIB_ARMOR_TRIM_SMITHING_TEMPLATE.builtInRegistryHolder(), new EssenceValue(knowledge, 1), false)
+                .add(Items.SPIRE_ARMOR_TRIM_SMITHING_TEMPLATE.builtInRegistryHolder(), new EssenceValue(knowledge, 1), false)
+                .add(Items.WAYFINDER_ARMOR_TRIM_SMITHING_TEMPLATE.builtInRegistryHolder(), new EssenceValue(knowledge, 1), false)
+                .add(Items.SHAPER_ARMOR_TRIM_SMITHING_TEMPLATE.builtInRegistryHolder(), new EssenceValue(knowledge, 1), false)
+                .add(Items.SILENCE_ARMOR_TRIM_SMITHING_TEMPLATE.builtInRegistryHolder(), new EssenceValue(knowledge, 1), false)
+                .add(Items.RAISER_ARMOR_TRIM_SMITHING_TEMPLATE.builtInRegistryHolder(), new EssenceValue(knowledge, 1), false)
+                .add(Items.HOST_ARMOR_TRIM_SMITHING_TEMPLATE.builtInRegistryHolder(), new EssenceValue(knowledge, 1), false)
+                .add(Items.FLOW_ARMOR_TRIM_SMITHING_TEMPLATE.builtInRegistryHolder(), new EssenceValue(knowledge, 1), false)
+                .add(Items.BOLT_ARMOR_TRIM_SMITHING_TEMPLATE.builtInRegistryHolder(), new EssenceValue(knowledge, 1), false);
+
+        // Light sources
+        this.builder(ModDataMaps.ESSENCE_VALUE_DATA)
+                .add(ItemTags.CANDLES, new EssenceValue(light, 1, animal, 1), false)
+                .add(Items.TORCH.builtInRegistryHolder(), new EssenceValue(fire, 1, light, 1), false)
+                .add(Items.SOUL_TORCH.builtInRegistryHolder(), new EssenceValue(nether, 1, light, 1), false)
+                .add(Items.CAMPFIRE.builtInRegistryHolder(), new EssenceValue(fire, 1, light, 1), false)
+                .add(Items.SOUL_CAMPFIRE.builtInRegistryHolder(), new EssenceValue(nether, 1, light, 1), false)
+                .add(Items.LANTERN.builtInRegistryHolder(), new EssenceValue(light, 1, metal, 1), false)
+                .add(Items.SOUL_LANTERN.builtInRegistryHolder(), new EssenceValue(light, 1, nether, 1), false)
+                .add(Items.REDSTONE_TORCH.builtInRegistryHolder(), new EssenceValue(power, 1, light, 1), false)
+                .add(Items.REDSTONE_LAMP.builtInRegistryHolder(), new EssenceValue(power, 1, light, 1), false)
+                .add(Items.COPPER_BULB.builtInRegistryHolder(), new EssenceValue(metal, 1, light, 1), false)
+                .add(Items.SHROOMLIGHT.builtInRegistryHolder(), new EssenceValue(light, 1, life, 1), false)
+                .add(Items.EXPOSED_COPPER_BULB.builtInRegistryHolder(), new EssenceValue(metal, 1, light, 1), false)
+                .add(Items.WEATHERED_COPPER_BULB.builtInRegistryHolder(), new EssenceValue(metal, 1, light, 1), false)
+                .add(Items.OXIDIZED_COPPER_BULB.builtInRegistryHolder(), new EssenceValue(metal, 1, light, 1), false)
+                .add(Items.WAXED_COPPER_BULB.builtInRegistryHolder(), new EssenceValue(metal, 1, light, 1), false)
+                .add(Items.WAXED_EXPOSED_COPPER_BULB.builtInRegistryHolder(), new EssenceValue(metal, 1, light, 1),
+                        false)
+                .add(Items.WAXED_WEATHERED_COPPER_BULB.builtInRegistryHolder(), new EssenceValue(metal, 1, light, 1),
+                        false)
+                .add(Items.WAXED_OXIDIZED_COPPER_BULB.builtInRegistryHolder(), new EssenceValue(metal, 1, light, 1),
+                        false)
+                .add(Items.GLOWSTONE_DUST.builtInRegistryHolder(), new EssenceValue(nether, 1, light, 1), false)
+                .add(Items.GLOWSTONE.builtInRegistryHolder(), new EssenceValue(nether, 1, light, 1), false)
+                .add(Items.JACK_O_LANTERN.builtInRegistryHolder(), new EssenceValue(light, 1, plant, 1), false)
+                .add(Items.SEA_LANTERN.builtInRegistryHolder(), new EssenceValue(light, 1, water, 1), false)
+                .add(Items.OCHRE_FROGLIGHT.builtInRegistryHolder(), new EssenceValue(light, 1, water, 1, life, 1), false)
+                .add(Items.VERDANT_FROGLIGHT.builtInRegistryHolder(), new EssenceValue(light, 1, water, 1, life, 1), false)
+                .add(Items.PEARLESCENT_FROGLIGHT.builtInRegistryHolder(), new EssenceValue(light, 1, water, 1, life, 1), false);
+
+        // Archaeology
+        this.builder(ModDataMaps.ESSENCE_VALUE_DATA)
+                .add(ItemTags.DECORATED_POT_SHERDS, new EssenceValue(earth, 1, order, 1), false)
+                .add(Items.DECORATED_POT.builtInRegistryHolder(), new EssenceValue(earth, 1, order, 1), false);
+
+        // Equipment
+        this.builder(ModDataMaps.ESSENCE_VALUE_DATA)
+                .add(Items.BUCKET.builtInRegistryHolder(), new EssenceValue(metal, 1), false)
+                .add(Items.LAVA_BUCKET.builtInRegistryHolder(), new EssenceValue(fire, 1), false)
+                .add(Tags.Items.TOOLS_SHIELD, new EssenceValue(chaos, 1), false)
+                .add(Items.HEAVY_CORE.builtInRegistryHolder(), new EssenceValue(metal, 1), false)
+                .add(Items.MACE.builtInRegistryHolder(), new EssenceValue(metal, 1, chaos, 1), false)
+                .add(Items.ELYTRA.builtInRegistryHolder(), new EssenceValue(air, 1), false)
+                .add(Items.TURTLE_HELMET.builtInRegistryHolder(), new EssenceValue(water, 1), false)
+                .add(Items.CROSSBOW.builtInRegistryHolder(), new EssenceValue(air, 1, chaos, 1), false)
+                .add(Items.BOW.builtInRegistryHolder(), new EssenceValue(air, 1, chaos, 1), false)
+                .add(Items.ARROW.builtInRegistryHolder(), new EssenceValue(air, 1, chaos, 1), false)
+                .add(Items.SPECTRAL_ARROW.builtInRegistryHolder(), new EssenceValue(death, 1, chaos, 1), false)
+                .add(Items.TIPPED_ARROW.builtInRegistryHolder(), new EssenceValue(chaos, 1), false)
+                .add(Items.WOODEN_SWORD.builtInRegistryHolder(), new EssenceValue(plant, 1, chaos, 1), false)
+                .add(Items.STONE_SWORD.builtInRegistryHolder(), new EssenceValue(earth, 1, chaos, 1), false)
+                .add(Items.IRON_SWORD.builtInRegistryHolder(), new EssenceValue(metal, 1, chaos, 1), false)
+                .add(Items.GOLDEN_SWORD.builtInRegistryHolder(), new EssenceValue(metal, 1, chaos, 1), false)
+                .add(Items.DIAMOND_SWORD.builtInRegistryHolder(), new EssenceValue(crystal, 1, chaos, 1), false)
+                .add(Items.NETHERITE_SWORD.builtInRegistryHolder(), new EssenceValue(nether, 1, metal, 1, chaos, 1), false)
+                .add(Items.WOODEN_AXE.builtInRegistryHolder(), new EssenceValue(plant, 1, chaos, 1), false)
+                .add(Items.STONE_AXE.builtInRegistryHolder(), new EssenceValue(earth, 1, chaos, 1), false)
+                .add(Items.IRON_AXE.builtInRegistryHolder(), new EssenceValue(metal, 1, chaos, 1), false)
+                .add(Items.GOLDEN_AXE.builtInRegistryHolder(), new EssenceValue(metal, 1, chaos, 1), false)
+                .add(Items.DIAMOND_AXE.builtInRegistryHolder(), new EssenceValue(crystal, 1, chaos, 1), false)
+                .add(Items.NETHERITE_AXE.builtInRegistryHolder(), new EssenceValue(metal, 1, nether, 1, chaos, 1), false)
+                .add(Items.WOODEN_SHOVEL.builtInRegistryHolder(), new EssenceValue(plant, 1, earth, 1), false)
+                .add(Items.STONE_SHOVEL.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
+                .add(Items.IRON_SHOVEL.builtInRegistryHolder(), new EssenceValue(metal, 1, earth, 1), false)
+                .add(Items.GOLDEN_SHOVEL.builtInRegistryHolder(), new EssenceValue(metal, 1, earth, 1), false)
+                .add(Items.DIAMOND_SHOVEL.builtInRegistryHolder(), new EssenceValue(crystal, 1, earth, 1), false)
+                .add(Items.NETHERITE_SHOVEL.builtInRegistryHolder(), new EssenceValue(metal, 1, nether, 1, earth, 1), false)
+                .add(Items.WOODEN_HOE.builtInRegistryHolder(), new EssenceValue(plant, 1, life, 1), false)
+                .add(Items.STONE_HOE.builtInRegistryHolder(), new EssenceValue(earth, 1, life, 1), false)
+                .add(Items.IRON_HOE.builtInRegistryHolder(), new EssenceValue(metal, 1, life, 1), false)
+                .add(Items.GOLDEN_HOE.builtInRegistryHolder(), new EssenceValue(metal, 1, life, 1), false)
+                .add(Items.DIAMOND_HOE.builtInRegistryHolder(), new EssenceValue(crystal, 1, life, 1), false)
+                .add(Items.NETHERITE_HOE.builtInRegistryHolder(), new EssenceValue(metal, 1, nether, 1, life, 1), false)
+                .add(Items.WOODEN_PICKAXE.builtInRegistryHolder(), new EssenceValue(plant, 1, earth, 1), false)
+                .add(Items.STONE_PICKAXE.builtInRegistryHolder(), new EssenceValue(earth, 1), false)
+                .add(Items.IRON_PICKAXE.builtInRegistryHolder(), new EssenceValue(metal, 1, earth, 1), false)
+                .add(Items.GOLDEN_PICKAXE.builtInRegistryHolder(), new EssenceValue(metal, 1, earth, 1), false)
+                .add(Items.DIAMOND_PICKAXE.builtInRegistryHolder(), new EssenceValue(crystal, 1, earth, 1), false)
+                .add(Items.NETHERITE_PICKAXE.builtInRegistryHolder(), new EssenceValue(metal, 1, nether, 1, earth, 1), false)
+
+                .add(Items.LEATHER_HELMET.builtInRegistryHolder(), new EssenceValue(animal, 1), false)
+                .add(Items.LEATHER_CHESTPLATE.builtInRegistryHolder(), new EssenceValue(animal, 1), false)
+                .add(Items.LEATHER_LEGGINGS.builtInRegistryHolder(), new EssenceValue(animal, 1), false)
+                .add(Items.LEATHER_BOOTS.builtInRegistryHolder(), new EssenceValue(animal, 1), false)
+                .add(Items.CHAINMAIL_HELMET.builtInRegistryHolder(), new EssenceValue(metal, 1), false)
+                .add(Items.CHAINMAIL_CHESTPLATE.builtInRegistryHolder(), new EssenceValue(metal, 1), false)
+                .add(Items.CHAINMAIL_LEGGINGS.builtInRegistryHolder(), new EssenceValue(metal, 1), false)
+                .add(Items.CHAINMAIL_BOOTS.builtInRegistryHolder(), new EssenceValue(metal, 1), false)
+                .add(Items.IRON_HELMET.builtInRegistryHolder(), new EssenceValue(metal, 1), false)
+                .add(Items.IRON_CHESTPLATE.builtInRegistryHolder(), new EssenceValue(metal, 1), false)
+                .add(Items.IRON_LEGGINGS.builtInRegistryHolder(), new EssenceValue(metal, 1), false)
+                .add(Items.IRON_BOOTS.builtInRegistryHolder(), new EssenceValue(metal, 1), false)
+                .add(Items.GOLDEN_HELMET.builtInRegistryHolder(), new EssenceValue(metal, 1), false)
+                .add(Items.GOLDEN_CHESTPLATE.builtInRegistryHolder(), new EssenceValue(metal, 1), false)
+                .add(Items.GOLDEN_LEGGINGS.builtInRegistryHolder(), new EssenceValue(metal, 1), false)
+                .add(Items.GOLDEN_BOOTS.builtInRegistryHolder(), new EssenceValue(metal, 1), false)
+                .add(Items.DIAMOND_HELMET.builtInRegistryHolder(), new EssenceValue(crystal, 1), false)
+                .add(Items.DIAMOND_CHESTPLATE.builtInRegistryHolder(), new EssenceValue(crystal, 1), false)
+                .add(Items.DIAMOND_LEGGINGS.builtInRegistryHolder(), new EssenceValue(crystal, 1), false)
+                .add(Items.DIAMOND_BOOTS.builtInRegistryHolder(), new EssenceValue(crystal, 1), false)
+                .add(Items.NETHERITE_HELMET.builtInRegistryHolder(), new EssenceValue(metal, 1, nether, 1), false)
+                .add(Items.NETHERITE_CHESTPLATE.builtInRegistryHolder(), new EssenceValue(metal, 1, nether, 1), false)
+                .add(Items.NETHERITE_LEGGINGS.builtInRegistryHolder(), new EssenceValue(metal, 1, nether, 1), false)
+                .add(Items.NETHERITE_BOOTS.builtInRegistryHolder(), new EssenceValue(metal, 1, nether, 1), false)
+
+                .add(Items.LEATHER_HORSE_ARMOR.builtInRegistryHolder(), new EssenceValue(animal, 1), false)
+                .add(Items.IRON_HORSE_ARMOR.builtInRegistryHolder(), new EssenceValue(metal, 1), false)
+                .add(Items.GOLDEN_HORSE_ARMOR.builtInRegistryHolder(), new EssenceValue(metal, 1), false)
+                .add(Items.DIAMOND_HORSE_ARMOR.builtInRegistryHolder(), new EssenceValue(crystal, 1), false)
+                .add(Items.TRIDENT.builtInRegistryHolder(), new EssenceValue(water, 1, chaos, 1), false);
+
+        // Other
+        this.builder(ModDataMaps.ESSENCE_VALUE_DATA)
+                .add(Items.BRUSH.builtInRegistryHolder(), new EssenceValue(order, 1), false)
+                .add(Items.TRIAL_KEY.builtInRegistryHolder(), new EssenceValue(chaos, 1), false)
+                .add(Items.OMINOUS_TRIAL_KEY.builtInRegistryHolder(), new EssenceValue(chaos, 1), false)
+                .add(Items.OMINOUS_BOTTLE.builtInRegistryHolder(), new EssenceValue(water, 1, chaos, 1), false)
+                .add(Items.FISHING_ROD.builtInRegistryHolder(), new EssenceValue(order, 1, plant, 1), false)
+                .add(Items.LEAD.builtInRegistryHolder(), new EssenceValue(order, 1, animal, 1), false)
+                .add(Items.NAME_TAG.builtInRegistryHolder(), new EssenceValue(order, 1), false)
+                .add(Items.SHEARS.builtInRegistryHolder(), new EssenceValue(order, 1, metal, 1), false)
+                .add(Items.CARROT_ON_A_STICK.builtInRegistryHolder(), new EssenceValue(plant, 1), false)
+                .add(Items.SADDLE.builtInRegistryHolder(), new EssenceValue(animal, 1), false)
+                .add(Items.WARPED_FUNGUS_ON_A_STICK.builtInRegistryHolder(), new EssenceValue(plant, 1, nether, 1),
+                        false)
+                .add(Items.WOLF_ARMOR.builtInRegistryHolder(), new EssenceValue(animal, 1), false)
+                .add(ItemTags.BUNDLES, new EssenceValue(animal, 1, order, 1), false)
+                .add(ItemTags.SHULKER_BOXES, new EssenceValue(end, 1, order, 1), false)
+                .add(Tags.Items.CHESTS_ENDER, new EssenceValue(space, 1, order, 1), false)
+                .add(Tags.Items.MUSIC_DISCS, new EssenceValue(order, 1, knowledge, 1), false)
+                .add(Items.DISC_FRAGMENT_5.builtInRegistryHolder(), new EssenceValue(order, 1, knowledge, 1), false)
+                .add(Items.JUKEBOX.builtInRegistryHolder(), new EssenceValue(order, 1, power, 1), false)
+                .add(Items.END_ROD.builtInRegistryHolder(), new EssenceValue(end, 1), false)
+
+                .add(Items.HOPPER.builtInRegistryHolder(), new EssenceValue(metal, 1), false)
+                .add(Items.LEVER.builtInRegistryHolder(), new EssenceValue(earth, 1, plant, 1), false)
+                .add(Items.LIGHTNING_ROD.builtInRegistryHolder(), new EssenceValue(metal, 1, air, 1), false)
+                .add(Items.TRIPWIRE_HOOK.builtInRegistryHolder(), new EssenceValue(metal, 1, plant, 1), false)
+
+                .add(Items.GUNPOWDER.builtInRegistryHolder(), new EssenceValue(fire, 1), false)
+                .add(Items.TNT.builtInRegistryHolder(), new EssenceValue(fire, 1), false)
+                .add(Items.FLINT_AND_STEEL.builtInRegistryHolder(), new EssenceValue(fire, 1, metal, 1), false)
+                .add(Items.BOWL.builtInRegistryHolder(), new EssenceValue(plant, 1), false)
+
+                .add(Items.REPEATER.builtInRegistryHolder(), new EssenceValue(power, 1), false)
+                .add(Items.COMPARATOR.builtInRegistryHolder(), new EssenceValue(power, 1), false)
+                .add(Items.PISTON.builtInRegistryHolder(), new EssenceValue(power, 1), false)
+                .add(Items.STICKY_PISTON.builtInRegistryHolder(), new EssenceValue(power, 1), false)
+                .add(Items.OBSERVER.builtInRegistryHolder(), new EssenceValue(power, 1), false)
+                .add(Items.DISPENSER.builtInRegistryHolder(), new EssenceValue(power, 1), false)
+                .add(Items.DROPPER.builtInRegistryHolder(), new EssenceValue(power, 1), false)
+                .add(Items.DAYLIGHT_DETECTOR.builtInRegistryHolder(), new EssenceValue(power, 1), false)
+
+                .add(Items.ITEM_FRAME.builtInRegistryHolder(), new EssenceValue(order, 1), false)
+                .add(Items.GLOW_ITEM_FRAME.builtInRegistryHolder(), new EssenceValue(order, 1, light, 1), false)
+                .add(Items.FLOWER_POT.builtInRegistryHolder(), new EssenceValue(order, 1, plant, 1), false)
+                .add(Items.PAINTING.builtInRegistryHolder(), new EssenceValue(order, 1), false)
+                .add(Items.COMPASS.builtInRegistryHolder(), new EssenceValue(space, 1, power, 1), false)
+                .add(Items.LODESTONE.builtInRegistryHolder(), new EssenceValue(space, 1), false)
+                .add(Items.RECOVERY_COMPASS.builtInRegistryHolder(), new EssenceValue(space, 1, death, 1), false)
+                .add(Items.RESPAWN_ANCHOR.builtInRegistryHolder(), new EssenceValue(nether, 1, death, 1), false)
+                .add(Items.CLOCK.builtInRegistryHolder(), new EssenceValue(time, 1), false)
+                .add(Items.SPYGLASS.builtInRegistryHolder(), new EssenceValue(space, 1), false)
+
+                .add(Items.FIREWORK_ROCKET.builtInRegistryHolder(), new EssenceValue(fire, 1), false)
+                .add(Items.FIREWORK_STAR.builtInRegistryHolder(), new EssenceValue(fire, 1), false)
+                .add(Items.ARMOR_STAND.builtInRegistryHolder(), new EssenceValue(order, 1), false)
+                .add(Items.TOTEM_OF_UNDYING.builtInRegistryHolder(), new EssenceValue(life, 1, death, 1), false)
+                .add(Items.GOAT_HORN.builtInRegistryHolder(), new EssenceValue(animal, 1, order, 1), false)
+                .add(Items.BELL.builtInRegistryHolder(), new EssenceValue(metal, 1), false)
+
+                .build();
     }
 }

--- a/src/main/java/com/wanderersoftherift/wotr/datagen/ModLanguageProvider.java
+++ b/src/main/java/com/wanderersoftherift/wotr/datagen/ModLanguageProvider.java
@@ -52,6 +52,7 @@ public class ModLanguageProvider extends LanguageProvider {
         addItem(ModItems.SKILL_THREAD, "Skill Thread");
 
         addEntityType(ModEntities.RIFT_ENTRANCE, "Rift Entrance");
+        addEntityType(ModEntities.RIFT_EXIT, "Rift Egress");
         addEntityType(ModEntities.SIMPLE_EFFECT_PROJECTILE, "Projectile");
 
         addEssenceType("earth", "Earth");

--- a/src/main/java/com/wanderersoftherift/wotr/item/essence/EssenceValue.java
+++ b/src/main/java/com/wanderersoftherift/wotr/item/essence/EssenceValue.java
@@ -27,6 +27,17 @@ public record EssenceValue(Object2IntMap<ResourceLocation> values) {
                 .unmodifiable(new Object2IntArrayMap<>(new ResourceLocation[] { type }, new int[] { value })));
     }
 
+    public EssenceValue(ResourceLocation type1, int value1, ResourceLocation type2, int value2) {
+        this(Object2IntMaps.unmodifiable(
+                new Object2IntArrayMap<>(new ResourceLocation[] { type1, type2 }, new int[] { value1, value2 })));
+    }
+
+    public EssenceValue(ResourceLocation type1, int value1, ResourceLocation type2, int value2, ResourceLocation type3,
+            int value3) {
+        this(Object2IntMaps.unmodifiable(new Object2IntArrayMap<>(new ResourceLocation[] { type1, type2, type3 },
+                new int[] { value1, value2, value3 })));
+    }
+
     /**
      * Map constructor
      */


### PR DESCRIPTION
This PR sets initial essence types for all vanilla items. Values are all 1 or 0, so a second pass is needed to set initial values.