### PR TITLE
feat: add ability to separately specify room and poi themes with spawnPiece command

### DIFF
--- a/src/main/java/com/wanderersoftherift/wotr/commands/SpawnPieceCommand.java
+++ b/src/main/java/com/wanderersoftherift/wotr/commands/SpawnPieceCommand.java
@@ -69,6 +69,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -89,6 +90,8 @@ public class SpawnPieceCommand {
         String rlArg = "resourcelocationpath";
         String locationArg = "location";
         String themeArg = "theme";
+        String roomArg = "room";
+        String poiArg = "poi";
         String terminateArg = "includeTerminators";
         String processorArg = "processor";
         String rotationArg = "rotation";
@@ -109,7 +112,7 @@ public class SpawnPieceCommand {
                                     Rotation.NONE, Mirror.NONE, 0, cs);
                             return 0;
                         })
-                        .then(Commands.literal("withPOIs")
+                        .then(Commands.literal("withPOIsAndTheme")
                                 .then(Commands.argument(themeArg, ResourceKeyArgument.key(ModRiftThemes.RIFT_THEME_KEY))
                                         .executes(cs -> {
                                             WorldCoordinates worldCoordinates = new WorldCoordinates(
@@ -124,7 +127,8 @@ public class SpawnPieceCommand {
                                             return 0;
                                         })
                                         .then(Commands.argument(locationArg, Vec3Argument.vec3()).executes(cs -> {
-                                            spawnPieceFully(cs.getArgument(rlArg, ResourceLocation.class),
+                                            spawnPieceFully(
+                                                    cs.getArgument(rlArg, ResourceLocation.class),
                                                     Vec3Argument.getCoordinates(cs, locationArg),
                                                     ResourceKeyArgument.resolveKey(cs, themeArg,
                                                             ModRiftThemes.RIFT_THEME_KEY, ERROR_INVALID_PROCESSOR),
@@ -159,6 +163,88 @@ public class SpawnPieceCommand {
                                                                             cs);
                                                                     return 0;
                                                                 }))))))
+                        .then(Commands.literal("withPOIs")
+                                .then(Commands.argument(roomArg, ResourceKeyArgument.key(Registries.PROCESSOR_LIST))
+                                        .then(Commands
+                                                .argument(poiArg, ResourceKeyArgument.key(Registries.PROCESSOR_LIST))
+                                                .executes(cs -> {
+                                                    WorldCoordinates worldCoordinates = new WorldCoordinates(
+                                                            new WorldCoordinate(false,
+                                                                    cs.getSource().getPosition().x()),
+                                                            new WorldCoordinate(false,
+                                                                    cs.getSource().getPosition().y()),
+                                                            new WorldCoordinate(false,
+                                                                    cs.getSource().getPosition().z()));
+                                                    spawnPieceFully(cs.getArgument(rlArg, ResourceLocation.class),
+                                                            worldCoordinates,
+                                                            ResourceKeyArgument.resolveKey(cs, roomArg,
+                                                                    Registries.PROCESSOR_LIST, ERROR_INVALID_PROCESSOR),
+                                                            ResourceKeyArgument.resolveKey(cs, poiArg,
+                                                                    Registries.PROCESSOR_LIST, ERROR_INVALID_PROCESSOR),
+                                                            true, cs.getSource().getLevel().getRandom().nextInt(), cs);
+                                                    return 0;
+                                                })
+                                                .then(Commands.argument(locationArg, Vec3Argument.vec3())
+                                                        .executes(cs -> {
+                                                            spawnPieceFully(
+                                                                    cs.getArgument(rlArg, ResourceLocation.class),
+                                                                    Vec3Argument.getCoordinates(cs, locationArg),
+                                                                    ResourceKeyArgument.resolveKey(cs, roomArg,
+                                                                            Registries.PROCESSOR_LIST,
+                                                                            ERROR_INVALID_PROCESSOR),
+                                                                    ResourceKeyArgument.resolveKey(cs, poiArg,
+                                                                            Registries.PROCESSOR_LIST,
+                                                                            ERROR_INVALID_PROCESSOR),
+                                                                    true,
+                                                                    cs.getSource().getLevel().getRandom().nextInt(),
+                                                                    cs);
+                                                            return 0;
+                                                        })
+                                                        .then(Commands.argument(terminateArg, BoolArgumentType.bool())
+                                                                .executes(cs -> {
+                                                                    spawnPieceFully(
+                                                                            cs.getArgument(rlArg,
+                                                                                    ResourceLocation.class),
+                                                                            Vec3Argument.getCoordinates(cs,
+                                                                                    locationArg),
+                                                                            ResourceKeyArgument.resolveKey(cs, roomArg,
+                                                                                    Registries.PROCESSOR_LIST,
+                                                                                    ERROR_INVALID_PROCESSOR),
+                                                                            ResourceKeyArgument.resolveKey(cs, poiArg,
+                                                                                    Registries.PROCESSOR_LIST,
+                                                                                    ERROR_INVALID_PROCESSOR),
+                                                                            BoolArgumentType.getBool(cs, terminateArg),
+                                                                            cs.getSource()
+                                                                                    .getLevel()
+                                                                                    .getRandom()
+                                                                                    .nextInt(),
+                                                                            cs);
+                                                                    return 0;
+                                                                })
+                                                                .then(Commands
+                                                                        .argument(seedArg,
+                                                                                IntegerArgumentType.integer())
+                                                                        .executes(cs -> {
+                                                                            spawnPieceFully(
+                                                                                    cs.getArgument(rlArg,
+                                                                                            ResourceLocation.class),
+                                                                                    Vec3Argument.getCoordinates(cs,
+                                                                                            locationArg),
+                                                                                    ResourceKeyArgument.resolveKey(cs,
+                                                                                            roomArg,
+                                                                                            Registries.PROCESSOR_LIST,
+                                                                                            ERROR_INVALID_PROCESSOR),
+                                                                                    ResourceKeyArgument.resolveKey(cs,
+                                                                                            poiArg,
+                                                                                            Registries.PROCESSOR_LIST,
+                                                                                            ERROR_INVALID_PROCESSOR),
+                                                                                    BoolArgumentType.getBool(cs,
+                                                                                            terminateArg),
+                                                                                    IntegerArgumentType.getInteger(cs,
+                                                                                            seedArg),
+                                                                                    cs);
+                                                                            return 0;
+                                                                        })))))))
                         .then(Commands.argument(locationArg, Vec3Argument.vec3()).executes(cs -> {
                             spawnPiece(cs.getArgument(rlArg, ResourceLocation.class),
                                     Vec3Argument.getCoordinates(cs, locationArg), null, Rotation.NONE, Mirror.NONE, 0,
@@ -273,6 +359,25 @@ public class SpawnPieceCommand {
         }
         BlockPos pos = coordinates.getBlockPos(cs.getSource());
         placeStructure(path, pos.mutable(), theme, includeTerminators, seed, cs);
+    }
+
+    public static void spawnPieceFully(
+            ResourceLocation path,
+            Coordinates coordinates,
+            Holder<StructureProcessorList> room,
+            Holder<StructureProcessorList> poi,
+            boolean includeTerminators,
+            int seed,
+            CommandContext<CommandSourceStack> cs) throws CommandSyntaxException {
+        if (cs.getSource().getEntity() instanceof Player player) {
+            player.displayClientMessage(Component.translatable("command.spawn_piece.generating", path.toString()),
+                    true);
+        }
+        BlockPos pos = coordinates.getBlockPos(cs.getSource());
+        Map<ThemePieceType, Holder<StructureProcessorList>> themeMap = Map.of(ThemePieceType.ROOM, room,
+                ThemePieceType.POI, poi);
+
+        placeStructure(path, pos.mutable(), new Holder.Direct<>(new RiftTheme(themeMap)), includeTerminators, seed, cs);
     }
 
     private static void generateStructurePiece(


### PR DESCRIPTION
The existing spawn fully capability now uses a `withPOIsAndTheme` literal, while `withPOIs` will now prompt for a room processor list and a poi processor list.