### PR TITLE
fix: #146 disable trial spawner ambient sounds

### DIFF
--- a/src/main/java/com/wanderersoftherift/wotr/commands/RiftCommands.java
+++ b/src/main/java/com/wanderersoftherift/wotr/commands/RiftCommands.java
@@ -2,7 +2,6 @@ package com.wanderersoftherift.wotr.commands;
 
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.mojang.brigadier.context.CommandContext;
-import com.wanderersoftherift.wotr.core.rift.RiftData;
 import com.wanderersoftherift.wotr.core.rift.RiftLevelManager;
 import net.minecraft.commands.CommandBuildContext;
 import net.minecraft.commands.CommandSourceStack;
@@ -28,7 +27,7 @@ public class RiftCommands extends BaseCommand {
         ServerPlayer player = ctx.getSource().getPlayer();
         ServerLevel level = ctx.getSource().getLevel();
 
-        if (player != null && RiftData.isRift(level)) {
+        if (player != null && RiftLevelManager.isRift(level)) {
             RiftLevelManager.returnPlayerFromRift(player);
             return 1;
         }

--- a/src/main/java/com/wanderersoftherift/wotr/core/inventory/snapshot/InventorySnapshotEvents.java
+++ b/src/main/java/com/wanderersoftherift/wotr/core/inventory/snapshot/InventorySnapshotEvents.java
@@ -1,7 +1,7 @@
 package com.wanderersoftherift.wotr.core.inventory.snapshot;
 
 import com.wanderersoftherift.wotr.WanderersOfTheRift;
-import com.wanderersoftherift.wotr.core.rift.RiftData;
+import com.wanderersoftherift.wotr.core.rift.RiftLevelManager;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.neoforged.bus.api.SubscribeEvent;
@@ -31,8 +31,8 @@ public class InventorySnapshotEvents {
                 || !(event.getEntity() instanceof ServerPlayer serverPlayer)) {
             return;
         }
-        boolean fromRift = RiftData.isRift(level.getServer().getLevel(event.getFrom()));
-        boolean toRift = RiftData.isRift(level.getServer().getLevel(event.getTo()));
+        boolean fromRift = RiftLevelManager.isRift(level.getServer().getLevel(event.getFrom()));
+        boolean toRift = RiftLevelManager.isRift(level.getServer().getLevel(event.getTo()));
         if (!fromRift && toRift) {
             InventorySnapshotSystem.captureSnapshot(serverPlayer);
         } else if (fromRift && !toRift) {

--- a/src/main/java/com/wanderersoftherift/wotr/core/rift/RiftData.java
+++ b/src/main/java/com/wanderersoftherift/wotr/core/rift/RiftData.java
@@ -2,12 +2,9 @@ package com.wanderersoftherift.wotr.core.rift;
 
 import com.wanderersoftherift.wotr.WanderersOfTheRift;
 import com.wanderersoftherift.wotr.item.riftkey.RiftConfig;
-import com.wanderersoftherift.wotr.world.level.RiftDimensionType;
 import net.minecraft.MethodsReturnNonnullByDefault;
 import net.minecraft.core.BlockPos;
-import net.minecraft.core.Holder;
 import net.minecraft.core.HolderLookup;
-import net.minecraft.core.Registry;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
@@ -20,7 +17,6 @@ import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.Level;
-import net.minecraft.world.level.dimension.DimensionType;
 import net.minecraft.world.level.saveddata.SavedData;
 
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -28,7 +24,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.UUID;
 
 @ParametersAreNonnullByDefault
@@ -46,15 +41,8 @@ public class RiftData extends SavedData { // TODO: split this
         this.config = config;
     }
 
-    public static boolean isRift(Level level) {
-        Registry<DimensionType> dimTypes = level.registryAccess().lookupOrThrow(Registries.DIMENSION_TYPE);
-        Optional<Holder.Reference<DimensionType>> riftType = dimTypes.get(RiftDimensionType.RIFT_DIMENSION_TYPE);
-        return riftType.filter(dimensionTypeReference -> dimensionTypeReference.value() == level.dimensionType())
-                .isPresent();
-    }
-
     public static RiftData get(ServerLevel level) {
-        if (!isRift(level)) {
+        if (!RiftLevelManager.isRift(level)) {
             throw new IllegalArgumentException("Not a rift level");
         }
         return level.getDataStorage()

--- a/src/main/java/com/wanderersoftherift/wotr/core/rift/RiftLevelManager.java
+++ b/src/main/java/com/wanderersoftherift/wotr/core/rift/RiftLevelManager.java
@@ -28,6 +28,7 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.biome.Biomes;
 import net.minecraft.world.level.biome.FixedBiomeSource;
 import net.minecraft.world.level.chunk.ChunkGenerator;
+import net.minecraft.world.level.dimension.DimensionType;
 import net.minecraft.world.level.dimension.LevelStem;
 import net.minecraft.world.level.levelgen.structure.pools.JigsawPlacement;
 import net.minecraft.world.level.storage.DerivedLevelData;
@@ -65,6 +66,17 @@ public final class RiftLevelManager {
     }
 
     /**
+     * @param level
+     * @return Whether the level is a rift
+     */
+    public static boolean isRift(Level level) {
+        Registry<DimensionType> dimTypes = level.registryAccess().lookupOrThrow(Registries.DIMENSION_TYPE);
+        Optional<Holder.Reference<DimensionType>> riftType = dimTypes.get(RiftDimensionType.RIFT_DIMENSION_TYPE);
+        return riftType.filter(dimensionTypeReference -> dimensionTypeReference.value() == level.dimensionType())
+                .isPresent();
+    }
+
+    /**
      * @param id
      * @return The rift level with the given id, if it exists
      */
@@ -72,14 +84,14 @@ public final class RiftLevelManager {
         var server = ServerLifecycleHooks.getCurrentServer();
 
         ServerLevel serverLevel = server.forgeGetWorldMap().get(ResourceKey.create(Registries.DIMENSION, id));
-        if (serverLevel != null && RiftData.isRift(serverLevel)) {
+        if (serverLevel != null && isRift(serverLevel)) {
             return serverLevel;
         }
         return null;
     }
 
     public static void onPlayerDeath(ServerPlayer player, ServerLevel level) {
-        if (!RiftData.isRift(level)) {
+        if (!isRift(level)) {
             return;
         }
         RiftData riftData = RiftData.get(player.serverLevel());
@@ -97,7 +109,7 @@ public final class RiftLevelManager {
      */
     public static boolean returnPlayerFromRift(ServerPlayer player) {
         ServerLevel riftLevel = player.serverLevel();
-        if (!RiftData.isRift(riftLevel)) {
+        if (!isRift(riftLevel)) {
             return false;
         }
 
@@ -220,7 +232,7 @@ public final class RiftLevelManager {
 
     @SuppressWarnings({ "unchecked", "deprecation" })
     private static void unregisterAndDeleteLevel(ServerLevel level) {
-        if (!RiftData.isRift(level)) {
+        if (!isRift(level)) {
             return;
         }
         RiftData riftData = RiftData.get(level);

--- a/src/main/java/com/wanderersoftherift/wotr/fix/DisableTrialSpawnerAmbient.java
+++ b/src/main/java/com/wanderersoftherift/wotr/fix/DisableTrialSpawnerAmbient.java
@@ -1,6 +1,7 @@
 package com.wanderersoftherift.wotr.fix;
 
 import com.wanderersoftherift.wotr.WanderersOfTheRift;
+import com.wanderersoftherift.wotr.core.rift.RiftLevelManager;
 import net.minecraft.client.Minecraft;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.sounds.SoundEvents;
@@ -31,7 +32,7 @@ public final class DisableTrialSpawnerAmbient {
     @SubscribeEvent
     public static void catchPlaySound(PlaySoundEvent event) {
         if (TRIAL_AMBIENT_SOUNDS.contains(event.getOriginalSound().getLocation())
-                && Minecraft.getInstance().level.dimension().location().getPath().startsWith("rift_")) {
+                && RiftLevelManager.isRift(Minecraft.getInstance().level)) {
             event.setSound(null);
         }
     }

--- a/src/main/java/com/wanderersoftherift/wotr/fix/DisableTrialSpawnerAmbient.java
+++ b/src/main/java/com/wanderersoftherift/wotr/fix/DisableTrialSpawnerAmbient.java
@@ -1,6 +1,7 @@
 package com.wanderersoftherift.wotr.fix;
 
 import com.wanderersoftherift.wotr.WanderersOfTheRift;
+import net.minecraft.client.Minecraft;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.sounds.SoundEvents;
 import net.neoforged.api.distmarker.Dist;
@@ -29,7 +30,8 @@ public final class DisableTrialSpawnerAmbient {
 
     @SubscribeEvent
     public static void catchPlaySound(PlaySoundEvent event) {
-        if (TRIAL_AMBIENT_SOUNDS.contains(event.getOriginalSound().getLocation())) {
+        if (TRIAL_AMBIENT_SOUNDS.contains(event.getOriginalSound().getLocation())
+                && Minecraft.getInstance().level.dimension().location().getPath().startsWith("rift_")) {
             event.setSound(null);
         }
     }

--- a/src/main/java/com/wanderersoftherift/wotr/fix/DisableTrialSpawnerAmbient.java
+++ b/src/main/java/com/wanderersoftherift/wotr/fix/DisableTrialSpawnerAmbient.java
@@ -1,0 +1,36 @@
+package com.wanderersoftherift.wotr.fix;
+
+import com.wanderersoftherift.wotr.WanderersOfTheRift;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.sounds.SoundEvents;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.client.event.sound.PlaySoundEvent;
+
+import java.util.List;
+
+/**
+ * Disables play of trial spawner ambient sounds - these play at any distance and the rifts are full of them so they
+ * quickly max available sounds.
+ * <p>
+ * Might be worth converting to a mixin for performance in the future
+ * </p>
+ */
+@EventBusSubscriber(modid = WanderersOfTheRift.MODID, bus = EventBusSubscriber.Bus.GAME, value = Dist.CLIENT)
+public final class DisableTrialSpawnerAmbient {
+
+    private static final List<ResourceLocation> TRIAL_AMBIENT_SOUNDS = List
+            .of(SoundEvents.TRIAL_SPAWNER_AMBIENT_OMINOUS.location(), SoundEvents.TRIAL_SPAWNER_AMBIENT.location());
+
+    private DisableTrialSpawnerAmbient() {
+
+    }
+
+    @SubscribeEvent
+    public static void catchPlaySound(PlaySoundEvent event) {
+        if (TRIAL_AMBIENT_SOUNDS.contains(event.getOriginalSound().getLocation())) {
+            event.setSound(null);
+        }
+    }
+}

--- a/src/main/java/com/wanderersoftherift/wotr/loot/LootUtil.java
+++ b/src/main/java/com/wanderersoftherift/wotr/loot/LootUtil.java
@@ -1,6 +1,7 @@
 package com.wanderersoftherift.wotr.loot;
 
 import com.wanderersoftherift.wotr.core.rift.RiftData;
+import com.wanderersoftherift.wotr.core.rift.RiftLevelManager;
 import com.wanderersoftherift.wotr.init.ModLootContextParams;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.storage.loot.LootContext;
@@ -11,7 +12,7 @@ public class LootUtil {
         Integer riftTier = context.getOptionalParameter(ModLootContextParams.RIFT_TIER);
         if (riftTier == null) {
             ServerLevel serverlevel = context.getLevel();
-            if (!RiftData.isRift(serverlevel)) {
+            if (!RiftLevelManager.isRift(serverlevel)) {
                 return 0;
             }
             riftTier = RiftData.get(serverlevel).getTier();

--- a/src/main/java/com/wanderersoftherift/wotr/loot/lootmodifiers/OverrideVanillaLootModifier.java
+++ b/src/main/java/com/wanderersoftherift/wotr/loot/lootmodifiers/OverrideVanillaLootModifier.java
@@ -2,7 +2,7 @@ package com.wanderersoftherift.wotr.loot.lootmodifiers;
 
 import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
-import com.wanderersoftherift.wotr.core.rift.RiftData;
+import com.wanderersoftherift.wotr.core.rift.RiftLevelManager;
 import com.wanderersoftherift.wotr.init.ModDataComponentType;
 import com.wanderersoftherift.wotr.item.implicit.GearImplicits;
 import com.wanderersoftherift.wotr.item.socket.GearSockets;
@@ -37,7 +37,7 @@ public class OverrideVanillaLootModifier extends LootModifier {
         // Check if the current level is a rift level and return
         // note this should never be the case, as the conditions from glm should prevent it
         ServerLevel serverlevel = context.getLevel();
-        if (RiftData.isRift(serverlevel)) {
+        if (RiftLevelManager.isRift(serverlevel)) {
             return generatedLoot;
         }
         ResourceKey<Level> dimension = context.getLevel().dimension();

--- a/src/main/java/com/wanderersoftherift/wotr/loot/lootmodifiers/RemoveEnchantedItemsModifier.java
+++ b/src/main/java/com/wanderersoftherift/wotr/loot/lootmodifiers/RemoveEnchantedItemsModifier.java
@@ -2,7 +2,7 @@ package com.wanderersoftherift.wotr.loot.lootmodifiers;
 
 import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
-import com.wanderersoftherift.wotr.core.rift.RiftData;
+import com.wanderersoftherift.wotr.core.rift.RiftLevelManager;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.item.ItemStack;
@@ -32,7 +32,7 @@ public class RemoveEnchantedItemsModifier extends LootModifier {
         // Check if the current level is a rift level and return
         // note this should never be the case, as the conditions from glm should prevent it
         ServerLevel serverlevel = context.getLevel();
-        if (RiftData.isRift(serverlevel)) {
+        if (RiftLevelManager.isRift(serverlevel)) {
             return generatedLoot;
         }
 

--- a/src/main/java/com/wanderersoftherift/wotr/rift/RiftDifficultyEvents.java
+++ b/src/main/java/com/wanderersoftherift/wotr/rift/RiftDifficultyEvents.java
@@ -2,6 +2,7 @@ package com.wanderersoftherift.wotr.rift;
 
 import com.wanderersoftherift.wotr.WanderersOfTheRift;
 import com.wanderersoftherift.wotr.core.rift.RiftData;
+import com.wanderersoftherift.wotr.core.rift.RiftLevelManager;
 import net.minecraft.core.Holder;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.LivingEntity;
@@ -22,7 +23,7 @@ public class RiftDifficultyEvents {
         if (event.getLevel().isClientSide() || event.getEntity() instanceof Player) {
             return;
         }
-        if (event.getLevel() instanceof ServerLevel serverLevel && RiftData.isRift(serverLevel)
+        if (event.getLevel() instanceof ServerLevel serverLevel && RiftLevelManager.isRift(serverLevel)
                 && event.getEntity() instanceof LivingEntity livingEntity) {
             applyDifficultyToEntity(livingEntity, serverLevel);
         }


### PR DESCRIPTION
This fix simply disables the playback of the trial spawner ambient sounds. We may want to do something with a little more finesse (like limiting the playback range) which is possible also.