### PR TITLE
fix: (#148) Prevent spectator use of abilities

### DIFF
--- a/src/main/java/com/wanderersoftherift/wotr/client/AbilityClientEvents.java
+++ b/src/main/java/com/wanderersoftherift/wotr/client/AbilityClientEvents.java
@@ -9,6 +9,7 @@ import com.wanderersoftherift.wotr.init.client.ModKeybinds;
 import com.wanderersoftherift.wotr.network.SelectAbilitySlotPayload;
 import net.minecraft.client.Minecraft;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.GameType;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
@@ -28,7 +29,9 @@ public final class AbilityClientEvents {
 
     @SubscribeEvent
     public static void processAbilityKeys(ClientTickEvent.Post event) {
-        if (Minecraft.getInstance().player == null) {
+        Minecraft minecraft = Minecraft.getInstance();
+        if (minecraft.player == null || minecraft.gameMode == null
+                || minecraft.gameMode.getPlayerMode() == GameType.SPECTATOR) {
             return;
         }
 

--- a/src/main/java/com/wanderersoftherift/wotr/gui/layer/AbilityBar.java
+++ b/src/main/java/com/wanderersoftherift/wotr/gui/layer/AbilityBar.java
@@ -23,6 +23,7 @@ import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.client.renderer.RenderType;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.level.GameType;
 import org.jetbrains.annotations.NotNull;
 import org.joml.Vector2i;
 import org.joml.Vector2ic;
@@ -84,7 +85,8 @@ public final class AbilityBar implements ConfigurableLayer {
     @Override
     public void render(@NotNull GuiGraphics graphics, @NotNull DeltaTracker deltaTracker) {
         Minecraft minecraft = Minecraft.getInstance();
-        if (minecraft.options.hideGui || !getConfig().isVisible()) {
+        if (minecraft.options.hideGui || !getConfig().isVisible() || minecraft.gameMode == null
+                || minecraft.gameMode.getPlayerMode() == GameType.SPECTATOR) {
             return;
         }
         LocalPlayer player = Minecraft.getInstance().player;

--- a/src/main/java/com/wanderersoftherift/wotr/gui/layer/ManaBar.java
+++ b/src/main/java/com/wanderersoftherift/wotr/gui/layer/ManaBar.java
@@ -18,6 +18,7 @@ import net.minecraft.client.renderer.RenderType;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.Mth;
+import net.minecraft.world.level.GameType;
 import org.jetbrains.annotations.NotNull;
 import org.joml.Math;
 import org.joml.Vector2i;
@@ -77,7 +78,8 @@ public class ManaBar implements ConfigurableLayer {
     @Override
     public void render(@NotNull GuiGraphics guiGraphics, @NotNull DeltaTracker deltaTracker) {
         Minecraft minecraft = Minecraft.getInstance();
-        if (minecraft.options.hideGui || !getConfig().isVisible()) {
+        if (minecraft.options.hideGui || !getConfig().isVisible() || minecraft.gameMode == null
+                || minecraft.gameMode.getPlayerMode() == GameType.SPECTATOR) {
             return;
         }
         LocalPlayer player = minecraft.player;

--- a/src/main/java/com/wanderersoftherift/wotr/network/SelectAbilitySlotPayload.java
+++ b/src/main/java/com/wanderersoftherift/wotr/network/SelectAbilitySlotPayload.java
@@ -7,6 +7,7 @@ import io.netty.buffer.ByteBuf;
 import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+import net.minecraft.server.level.ServerPlayer;
 import net.neoforged.neoforge.network.handling.IPayloadContext;
 import org.jetbrains.annotations.NotNull;
 
@@ -28,7 +29,9 @@ public record SelectAbilitySlotPayload(int slot) implements CustomPacketPayload 
     }
 
     public void handleOnServer(IPayloadContext context) {
-        AbilitySlots abilitySlots = context.player().getData(ModAttachments.ABILITY_SLOTS);
-        abilitySlots.setSelectedSlot(slot);
+        if (context.player() instanceof ServerPlayer player && !player.isSpectator()) {
+            AbilitySlots abilitySlots = player.getData(ModAttachments.ABILITY_SLOTS);
+            abilitySlots.setSelectedSlot(slot);
+        }
     }
 }

--- a/src/main/java/com/wanderersoftherift/wotr/network/UseAbilityPayload.java
+++ b/src/main/java/com/wanderersoftherift/wotr/network/UseAbilityPayload.java
@@ -10,6 +10,7 @@ import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.item.ItemStack;
 import net.neoforged.neoforge.network.handling.IPayloadContext;
 
@@ -26,7 +27,10 @@ public record UseAbilityPayload(int slot) implements CustomPacketPayload {
     }
 
     public void handleOnServer(final IPayloadContext context) {
-        AbilitySlots abilitySlots = context.player().getData(ModAttachments.ABILITY_SLOTS);
+        if (!(context.player() instanceof ServerPlayer player) || player.isSpectator() || player.isDeadOrDying()) {
+            return;
+        }
+        AbilitySlots abilitySlots = player.getData(ModAttachments.ABILITY_SLOTS);
         ItemStack abilityItem = abilitySlots.getStackInSlot(slot());
         if (abilityItem.isEmpty() || !abilityItem.has(ModDataComponentType.ABILITY)) {
             return;
@@ -36,17 +40,17 @@ public record UseAbilityPayload(int slot) implements CustomPacketPayload {
 
         if (ability.isToggle()) // Should check last toggle, because pressing a button can send multiple packets
         {
-            if (!ability.isToggled(context.player())) {
-                ability.onActivate(context.player(), slot(), abilityItem);
+            if (!ability.isToggled(player)) {
+                ability.onActivate(player, slot(), abilityItem);
             } else {
-                ability.onDeactivate(context.player(), slot());
+                ability.onDeactivate(player, slot());
             }
 
-            if (ability.canPlayerUse(context.player())) {
-                ability.toggle(context.player());
+            if (ability.canPlayerUse(player)) {
+                ability.toggle(player);
             }
         } else {
-            ability.onActivate(context.player(), slot(), abilityItem);
+            ability.onActivate(player, slot(), abilityItem);
         }
     }
 }


### PR DESCRIPTION
This PR
 - Hides the Ability Bar and Mana Bar when spectating
 - Disables the ability keybinds while spectating
 - Rejects ability usage packets server-side for spectating players

Closes #148 