### PR TITLE
fix: (#154) Limit random selectable rift themes and objectives

### DIFF
--- a/src/generated/resources/data/wotr/tags/wotr/objective/random_selectable.json
+++ b/src/generated/resources/data/wotr/tags/wotr/objective/random_selectable.json
@@ -1,0 +1,8 @@
+{
+  "values": [
+    {
+      "id": "wotr:kill",
+      "required": false
+    }
+  ]
+}

--- a/src/generated/resources/data/wotr/tags/wotr/rift_theme/random_selectable.json
+++ b/src/generated/resources/data/wotr/tags/wotr/rift_theme/random_selectable.json
@@ -7,6 +7,10 @@
     {
       "id": "wotr:forest",
       "required": false
+    },
+    {
+      "id": "wotr:mushroom",
+      "required": false
     }
   ]
 }

--- a/src/generated/resources/data/wotr/tags/wotr/rift_theme/random_selectable.json
+++ b/src/generated/resources/data/wotr/tags/wotr/rift_theme/random_selectable.json
@@ -1,0 +1,12 @@
+{
+  "values": [
+    {
+      "id": "wotr:cave",
+      "required": false
+    },
+    {
+      "id": "wotr:forest",
+      "required": false
+    }
+  ]
+}

--- a/src/main/java/com/wanderersoftherift/wotr/datagen/DataGenerators.java
+++ b/src/main/java/com/wanderersoftherift/wotr/datagen/DataGenerators.java
@@ -2,6 +2,7 @@ package com.wanderersoftherift.wotr.datagen;
 
 import com.wanderersoftherift.wotr.WanderersOfTheRift;
 import com.wanderersoftherift.wotr.init.ModDamageTypes;
+import com.wanderersoftherift.wotr.init.ModRiftThemes;
 import com.wanderersoftherift.wotr.init.RegistryEvents;
 import net.minecraft.core.RegistrySetBuilder;
 import net.minecraft.core.registries.Registries;
@@ -28,7 +29,12 @@ public class DataGenerators {
                             ModDamageTypes.FIRE_DAMAGE, new DamageType("wotr.fire", DamageScaling.NEVER, 0.0F));
                     bootstrap.register(
                             ModDamageTypes.ICE_DAMAGE, new DamageType("wotr.ice", DamageScaling.NEVER, 0.0F));
-                }).add(RegistryEvents.ABILITY_REGISTRY, ModAbilityProvider::bootstrapAbilities)
+                })
+                        .add(RegistryEvents.ABILITY_REGISTRY, ModAbilityProvider::bootstrapAbilities)
+                        .add(RegistryEvents.OBJECTIVE_REGISTRY, context -> {
+                        })
+                        .add(ModRiftThemes.RIFT_THEME_KEY, context -> {
+                        })
         );
         event.createProvider(ModLanguageProvider::new);
         event.createProvider(ModModelProvider::new);
@@ -41,6 +47,8 @@ public class DataGenerators {
         event.createProvider((output, lookupProvider) -> new ModItemTagProvider(output, lookupProvider,
                 modBlockTagProvider.contentsGetter()));
         event.createProvider(ModAbilityTagsProvider::new);
+        event.createProvider(ModRiftThemeTagsProvider::new);
+        event.createProvider(ModObjectiveTagsProvider::new);
 
         // event.createProvider(ModAbilityProvider::new);
         event.createProvider(ModRiftThemeRecipeProvider::new);

--- a/src/main/java/com/wanderersoftherift/wotr/datagen/ModObjectiveTagsProvider.java
+++ b/src/main/java/com/wanderersoftherift/wotr/datagen/ModObjectiveTagsProvider.java
@@ -1,0 +1,25 @@
+package com.wanderersoftherift.wotr.datagen;
+
+import com.wanderersoftherift.wotr.WanderersOfTheRift;
+import com.wanderersoftherift.wotr.init.ModTags;
+import com.wanderersoftherift.wotr.init.RegistryEvents;
+import com.wanderersoftherift.wotr.rift.objective.ObjectiveType;
+import net.minecraft.core.HolderLookup;
+import net.minecraft.data.PackOutput;
+import net.minecraft.data.tags.TagsProvider;
+import net.minecraft.tags.TagEntry;
+
+import java.util.concurrent.CompletableFuture;
+
+public class ModObjectiveTagsProvider extends TagsProvider<ObjectiveType> {
+    // Get parameters from the `GatherDataEvent`s.
+    public ModObjectiveTagsProvider(PackOutput output, CompletableFuture<HolderLookup.Provider> lookupProvider) {
+        // Second parameter is the registry key we are generating the tags for.
+        super(output, RegistryEvents.OBJECTIVE_REGISTRY, lookupProvider, WanderersOfTheRift.MODID);
+    }
+
+    @Override
+    protected void addTags(HolderLookup.Provider lookupProvider) {
+        tag(ModTags.Objectives.RANDOM_SELECTABLE).add(TagEntry.optionalElement(WanderersOfTheRift.id("kill")));
+    }
+}

--- a/src/main/java/com/wanderersoftherift/wotr/datagen/ModRiftThemeTagsProvider.java
+++ b/src/main/java/com/wanderersoftherift/wotr/datagen/ModRiftThemeTagsProvider.java
@@ -21,6 +21,7 @@ public class ModRiftThemeTagsProvider extends TagsProvider<RiftTheme> {
     @Override
     protected void addTags(HolderLookup.Provider lookupProvider) {
         tag(ModTags.RiftThemes.RANDOM_SELECTABLE).add(TagEntry.optionalElement(WanderersOfTheRift.id("cave")))
-                .add(TagEntry.optionalElement(WanderersOfTheRift.id("forest")));
+                .add(TagEntry.optionalElement(WanderersOfTheRift.id("forest")))
+                .add(TagEntry.optionalElement(WanderersOfTheRift.id("mushroom")));
     }
 }

--- a/src/main/java/com/wanderersoftherift/wotr/datagen/ModRiftThemeTagsProvider.java
+++ b/src/main/java/com/wanderersoftherift/wotr/datagen/ModRiftThemeTagsProvider.java
@@ -1,0 +1,26 @@
+package com.wanderersoftherift.wotr.datagen;
+
+import com.wanderersoftherift.wotr.WanderersOfTheRift;
+import com.wanderersoftherift.wotr.init.ModRiftThemes;
+import com.wanderersoftherift.wotr.init.ModTags;
+import com.wanderersoftherift.wotr.world.level.levelgen.theme.RiftTheme;
+import net.minecraft.core.HolderLookup;
+import net.minecraft.data.PackOutput;
+import net.minecraft.data.tags.TagsProvider;
+import net.minecraft.tags.TagEntry;
+
+import java.util.concurrent.CompletableFuture;
+
+public class ModRiftThemeTagsProvider extends TagsProvider<RiftTheme> {
+    // Get parameters from the `GatherDataEvent`s.
+    public ModRiftThemeTagsProvider(PackOutput output, CompletableFuture<HolderLookup.Provider> lookupProvider) {
+        // Second parameter is the registry key we are generating the tags for.
+        super(output, ModRiftThemes.RIFT_THEME_KEY, lookupProvider, WanderersOfTheRift.MODID);
+    }
+
+    @Override
+    protected void addTags(HolderLookup.Provider lookupProvider) {
+        tag(ModTags.RiftThemes.RANDOM_SELECTABLE).add(TagEntry.optionalElement(WanderersOfTheRift.id("cave")))
+                .add(TagEntry.optionalElement(WanderersOfTheRift.id("forest")));
+    }
+}

--- a/src/main/java/com/wanderersoftherift/wotr/init/ModTags.java
+++ b/src/main/java/com/wanderersoftherift/wotr/init/ModTags.java
@@ -3,6 +3,8 @@ package com.wanderersoftherift.wotr.init;
 import com.wanderersoftherift.wotr.WanderersOfTheRift;
 import com.wanderersoftherift.wotr.abilities.AbstractAbility;
 import com.wanderersoftherift.wotr.item.runegem.RunegemData;
+import com.wanderersoftherift.wotr.rift.objective.ObjectiveType;
+import com.wanderersoftherift.wotr.world.level.levelgen.theme.RiftTheme;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.BlockTags;
 import net.minecraft.tags.ItemTags;
@@ -65,6 +67,25 @@ public class ModTags {
 
         private static TagKey<AbstractAbility> createTag(String name) {
             return TagKey.create(RegistryEvents.ABILITY_REGISTRY, ResourceLocation.fromNamespaceAndPath("wotr", name));
+        }
+    }
+
+    public static class RiftThemes {
+
+        public static final TagKey<RiftTheme> RANDOM_SELECTABLE = createTag("random_selectable");
+
+        private static TagKey<RiftTheme> createTag(String name) {
+            return TagKey.create(ModRiftThemes.RIFT_THEME_KEY, ResourceLocation.fromNamespaceAndPath("wotr", name));
+        }
+    }
+
+    public static class Objectives {
+
+        public static final TagKey<ObjectiveType> RANDOM_SELECTABLE = createTag("random_selectable");
+
+        private static TagKey<ObjectiveType> createTag(String name) {
+            return TagKey.create(RegistryEvents.OBJECTIVE_REGISTRY,
+                    ResourceLocation.fromNamespaceAndPath("wotr", name));
         }
     }
 }

--- a/src/main/java/com/wanderersoftherift/wotr/rift/objective/RiftObjectiveEvents.java
+++ b/src/main/java/com/wanderersoftherift/wotr/rift/objective/RiftObjectiveEvents.java
@@ -7,6 +7,7 @@ import com.wanderersoftherift.wotr.core.rift.RiftLevelManager;
 import com.wanderersoftherift.wotr.gui.menu.RiftCompleteMenu;
 import com.wanderersoftherift.wotr.init.ModAttachments;
 import com.wanderersoftherift.wotr.init.ModLootContextParams;
+import com.wanderersoftherift.wotr.init.ModTags;
 import com.wanderersoftherift.wotr.init.RegistryEvents;
 import com.wanderersoftherift.wotr.item.riftkey.RiftConfig;
 import com.wanderersoftherift.wotr.network.S2CRiftObjectiveStatusPacket;
@@ -49,7 +50,7 @@ public class RiftObjectiveEvents {
                 .orElseGet(() -> event.getLevel()
                         .registryAccess()
                         .lookupOrThrow(RegistryEvents.OBJECTIVE_REGISTRY)
-                        .getRandom(event.getLevel().getRandom())
+                        .getRandomElementOf(ModTags.Objectives.RANDOM_SELECTABLE, event.getLevel().getRandom())
                         .orElseThrow(() -> new IllegalStateException("No objectives available")));
 
         OngoingObjective objective = objectiveType.value().generate(event.getLevel());

--- a/src/main/java/com/wanderersoftherift/wotr/world/level/levelgen/theme/LevelRiftThemeData.java
+++ b/src/main/java/com/wanderersoftherift/wotr/world/level/levelgen/theme/LevelRiftThemeData.java
@@ -2,7 +2,6 @@ package com.wanderersoftherift.wotr.world.level.levelgen.theme;
 
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
-import com.wanderersoftherift.wotr.WanderersOfTheRift;
 import com.wanderersoftherift.wotr.init.ModRiftThemes;
 import com.wanderersoftherift.wotr.init.ModTags;
 import net.minecraft.core.Holder;
@@ -12,6 +11,7 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.NbtOps;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.saveddata.SavedData;
+import org.jetbrains.annotations.NotNull;
 
 import static com.wanderersoftherift.wotr.WanderersOfTheRift.LOGGER;
 
@@ -44,7 +44,7 @@ public class LevelRiftThemeData extends SavedData {
     }
 
     @Override
-    public CompoundTag save(CompoundTag tag, HolderLookup.Provider registries) {
+    public @NotNull CompoundTag save(@NotNull CompoundTag tag, HolderLookup.@NotNull Provider registries) {
         RiftTheme.CODEC.encodeStart(NbtOps.INSTANCE, this.getTheme())
                 .resultOrPartial(LOGGER::error)
                 .ifPresent(compound -> tag.put("theme", compound));
@@ -62,12 +62,8 @@ public class LevelRiftThemeData extends SavedData {
 
     public static Holder<RiftTheme> getRandomTheme(ServerLevel level) {
         Registry<RiftTheme> registry = level.registryAccess().lookupOrThrow(ModRiftThemes.RIFT_THEME_KEY);
-        var riftTheme = registry.get(ModTags.RiftThemes.RANDOM_SELECTABLE)
-                .flatMap(x -> x.getRandomElement(level.getRandom()))
-                .orElse(null);
-        if (riftTheme == null) {
-            WanderersOfTheRift.LOGGER.error("Failed to get random rift theme");
-        }
-        return riftTheme;
+
+        return registry.getRandomElementOf(ModTags.RiftThemes.RANDOM_SELECTABLE, level.getRandom())
+                .orElseThrow(() -> new IllegalStateException("No rift themes available"));
     }
 }

--- a/src/main/java/com/wanderersoftherift/wotr/world/level/levelgen/theme/LevelRiftThemeData.java
+++ b/src/main/java/com/wanderersoftherift/wotr/world/level/levelgen/theme/LevelRiftThemeData.java
@@ -4,6 +4,7 @@ import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import com.wanderersoftherift.wotr.WanderersOfTheRift;
 import com.wanderersoftherift.wotr.init.ModRiftThemes;
+import com.wanderersoftherift.wotr.init.ModTags;
 import net.minecraft.core.Holder;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.core.Registry;
@@ -11,8 +12,6 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.NbtOps;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.saveddata.SavedData;
-
-import java.util.Optional;
 
 import static com.wanderersoftherift.wotr.WanderersOfTheRift.LOGGER;
 
@@ -62,8 +61,10 @@ public class LevelRiftThemeData extends SavedData {
     }
 
     public static Holder<RiftTheme> getRandomTheme(ServerLevel level) {
-        Optional<Registry<RiftTheme>> registryReference = level.registryAccess().lookup(ModRiftThemes.RIFT_THEME_KEY);
-        var riftTheme = registryReference.flatMap(x -> x.getRandom(level.getRandom())).orElse(null);
+        Registry<RiftTheme> registry = level.registryAccess().lookupOrThrow(ModRiftThemes.RIFT_THEME_KEY);
+        var riftTheme = registry.get(ModTags.RiftThemes.RANDOM_SELECTABLE)
+                .flatMap(x -> x.getRandomElement(level.getRandom()))
+                .orElse(null);
         if (riftTheme == null) {
             WanderersOfTheRift.LOGGER.error("Failed to get random rift theme");
         }


### PR DESCRIPTION
This PR adds tags to control the valid rift themes and objectives when selecting randomly for an uninitialized (creative menu generated) key.

Closes #154