### PR TITLE
fix:Added spawner processor to custom POI processor files

### DIFF
--- a/src/main/resources/data/wotr/worldgen/processor_list/poi_11_to_glass.json
+++ b/src/main/resources/data/wotr/worldgen/processor_list/poi_11_to_glass.json
@@ -58,6 +58,10 @@
         {
             "processor_type": "wotr:rift_theme",
             "piece_type": "poi"
+        },
+        {
+            "processor_type": "wotr:trial_spawner",
+            "config": "wotr:rift"
         }
     ]
 }

--- a/src/main/resources/data/wotr/worldgen/processor_list/poi_12_to_wood.json
+++ b/src/main/resources/data/wotr/worldgen/processor_list/poi_12_to_wood.json
@@ -148,6 +148,10 @@
         {
             "processor_type": "wotr:rift_theme",
             "piece_type": "poi"
+        },
+        {
+            "processor_type": "wotr:trial_spawner",
+            "config": "wotr:rift"
         }
     ]
 }

--- a/src/main/resources/data/wotr/worldgen/processor_list/poi_multiple_ruins_and_wood.json
+++ b/src/main/resources/data/wotr/worldgen/processor_list/poi_multiple_ruins_and_wood.json
@@ -274,6 +274,10 @@
         {
             "processor_type": "wotr:rift_theme",
             "piece_type": "poi"
+        },
+        {
+            "processor_type": "wotr:trial_spawner",
+            "config": "wotr:rift"
         }
     ]
 }


### PR DESCRIPTION
Tested glass and tree, spawners now work for those POIs. I don't believe the "ruins and wood" one is in use with any POIs today per the builder spreadsheet, but updated in case it gets used later.