### PR TITLE
fix: Set mob current health after max health is changed

### DIFF
--- a/src/main/java/com/wanderersoftherift/wotr/rift/RiftDifficultyEvents.java
+++ b/src/main/java/com/wanderersoftherift/wotr/rift/RiftDifficultyEvents.java
@@ -35,6 +35,7 @@ public class RiftDifficultyEvents {
             updateAttribute(mob, Attributes.ATTACK_DAMAGE, getDamageMultiplier(tier));
             updateAttribute(mob, Attributes.MAX_HEALTH, getHealthMultiplier(tier));
             updateAttribute(mob, Attributes.MOVEMENT_SPEED, getSpeedMultiplier(tier));
+            livingEntity.setHealth(livingEntity.getMaxHealth());
         }
     }
 


### PR DESCRIPTION
fix: Set mob current health after max health is changed during mob spawn.