### PR TITLE
feat: reworked key forge recipes to be more flexible

### DIFF
--- a/src/generated/resources/data/wotr/wotr/key_forge_recipe/cave.json
+++ b/src/generated/resources/data/wotr/wotr/key_forge_recipe/cave.json
@@ -1,0 +1,7 @@
+{
+  "output": {
+    "type": "wotr:rift_theme",
+    "value": "wotr:cave"
+  },
+  "priority": -1
+}

--- a/src/generated/resources/data/wotr/wotr/key_forge_recipe/forest.json
+++ b/src/generated/resources/data/wotr/wotr/key_forge_recipe/forest.json
@@ -5,6 +5,9 @@
       "minPercent": 50.0
     }
   ],
-  "output": "wotr:forest",
+  "output": {
+    "type": "wotr:rift_theme",
+    "value": "wotr:forest"
+  },
   "priority": 0
 }

--- a/src/generated/resources/data/wotr/wotr/key_forge_recipe/kill.json
+++ b/src/generated/resources/data/wotr/wotr/key_forge_recipe/kill.json
@@ -1,0 +1,7 @@
+{
+  "output": {
+    "type": "wotr:rift_objective",
+    "value": "wotr:kill"
+  },
+  "priority": -1
+}

--- a/src/generated/resources/data/wotr/wotr/key_forge_recipe/mushroom.json
+++ b/src/generated/resources/data/wotr/wotr/key_forge_recipe/mushroom.json
@@ -5,6 +5,9 @@
       "minPercent": 50.0
     }
   ],
-  "output": "wotr:mushroom",
+  "output": {
+    "type": "wotr:rift_theme",
+    "value": "wotr:mushroom"
+  },
   "priority": 10
 }

--- a/src/generated/resources/data/wotr/wotr/key_forge_recipe/nether.json
+++ b/src/generated/resources/data/wotr/wotr/key_forge_recipe/nether.json
@@ -5,6 +5,9 @@
       "minPercent": 50.0
     }
   ],
-  "output": "wotr:nether",
+  "output": {
+    "type": "wotr:rift_theme",
+    "value": "wotr:nether"
+  },
   "priority": 10
 }

--- a/src/generated/resources/data/wotr/wotr/key_forge_recipe/noir.json
+++ b/src/generated/resources/data/wotr/wotr/key_forge_recipe/noir.json
@@ -5,6 +5,9 @@
       "minPercent": 50.0
     }
   ],
-  "output": "wotr:noir",
+  "output": {
+    "type": "wotr:rift_theme",
+    "value": "wotr:noir"
+  },
   "priority": 10
 }

--- a/src/generated/resources/data/wotr/wotr/key_forge_recipe/processor.json
+++ b/src/generated/resources/data/wotr/wotr/key_forge_recipe/processor.json
@@ -5,6 +5,9 @@
       "minPercent": 1.0
     }
   ],
-  "output": "wotr:processor",
+  "output": {
+    "type": "wotr:rift_theme",
+    "value": "wotr:processor"
+  },
   "priority": 0
 }

--- a/src/generated/resources/data/wotr/wotr/key_forge_recipe/stealth.json
+++ b/src/generated/resources/data/wotr/wotr/key_forge_recipe/stealth.json
@@ -5,6 +5,9 @@
       "minPercent": 5.0
     }
   ],
-  "output": "wotr:stealth",
+  "output": {
+    "type": "wotr:rift_objective",
+    "value": "wotr:stealth"
+  },
   "priority": 0
 }

--- a/src/generated/resources/data/wotr/wotr/rift_objective_recipe/kill.json
+++ b/src/generated/resources/data/wotr/wotr/rift_objective_recipe/kill.json
@@ -1,4 +1,0 @@
-{
-  "output": "wotr:kill",
-  "priority": -1
-}

--- a/src/generated/resources/data/wotr/wotr/rift_theme_recipe/cave.json
+++ b/src/generated/resources/data/wotr/wotr/rift_theme_recipe/cave.json
@@ -1,4 +1,0 @@
-{
-  "output": "wotr:cave",
-  "priority": -1
-}

--- a/src/main/java/com/wanderersoftherift/wotr/codec/DispatchedPair.java
+++ b/src/main/java/com/wanderersoftherift/wotr/codec/DispatchedPair.java
@@ -1,0 +1,38 @@
+package com.wanderersoftherift.wotr.codec;
+
+import com.mojang.datafixers.util.Pair;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.DataResult;
+import com.mojang.serialization.DynamicOps;
+
+import java.util.function.Function;
+
+/**
+ * Codec for a pair where the Codec for the second value is determined by the first value
+ * 
+ * @param keyCodec           The codec for the key, which should have field specified
+ * @param valueField         The field for the value
+ * @param valueCodecFunction The function for obtaining the value codec from the key
+ * @param <K>                Type of the key
+ * @param <V>                Type of the value
+ */
+public record DispatchedPair<K, V>(Codec<K> keyCodec, String valueField, Function<K, Codec<V>> valueCodecFunction)
+        implements Codec<Pair<K, V>> {
+
+    @Override
+    public <T> DataResult<T> encode(final Pair<K, V> input, final DynamicOps<T> ops, final T rest) {
+        Codec<V> valueCodec = valueCodecFunction.apply(input.getFirst()).fieldOf(valueField).codec();
+        return valueCodec.encode(input.getSecond(), ops, rest).flatMap(f -> keyCodec.encode(input.getFirst(), ops, f));
+    }
+
+    @Override
+    public <T> DataResult<Pair<Pair<K, V>, T>> decode(final DynamicOps<T> ops, final T input) {
+        return keyCodec.decode(ops, input).flatMap(p1 -> {
+            Codec<V> valueCodec = valueCodecFunction.apply(p1.getFirst()).fieldOf(valueField).codec();
+            return valueCodec.decode(ops, p1.getSecond())
+                    .map(p2 -> Pair.of(Pair.of(p1.getFirst(), p2.getFirst()), p2.getSecond())
+                    );
+        });
+    }
+
+}

--- a/src/main/java/com/wanderersoftherift/wotr/datagen/WotrObjectiveRecipeProvider.java
+++ b/src/main/java/com/wanderersoftherift/wotr/datagen/WotrObjectiveRecipeProvider.java
@@ -6,8 +6,10 @@ import com.wanderersoftherift.wotr.init.WotrDataComponentType;
 import com.wanderersoftherift.wotr.init.WotrRegistries;
 import com.wanderersoftherift.wotr.item.riftkey.EssencePredicate;
 import com.wanderersoftherift.wotr.item.riftkey.KeyForgeRecipe;
+import net.minecraft.core.Holder;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.data.PackOutput;
+import net.minecraft.resources.ResourceLocation;
 import net.neoforged.neoforge.registries.DeferredHolder;
 
 import java.util.concurrent.CompletableFuture;
@@ -16,7 +18,8 @@ import java.util.function.Consumer;
 public class WotrObjectiveRecipeProvider extends KeyForgeRecipeProvider {
 
     public WotrObjectiveRecipeProvider(PackOutput output, CompletableFuture<HolderLookup.Provider> registries) {
-        super("RiftObjectiveRecipe", output, registries);
+        super("RiftObjectiveRecipe", output, registries,
+                (recipe) -> ResourceLocation.parse(((Holder<?>) recipe.getOutput()).getRegisteredName()));
     }
 
     @Override

--- a/src/main/java/com/wanderersoftherift/wotr/datagen/WotrObjectiveRecipeProvider.java
+++ b/src/main/java/com/wanderersoftherift/wotr/datagen/WotrObjectiveRecipeProvider.java
@@ -1,13 +1,11 @@
 package com.wanderersoftherift.wotr.datagen;
 
 import com.wanderersoftherift.wotr.WanderersOfTheRift;
-import com.wanderersoftherift.wotr.codec.LaxRegistryCodec;
 import com.wanderersoftherift.wotr.datagen.provider.KeyForgeRecipeProvider;
+import com.wanderersoftherift.wotr.init.WotrDataComponentType;
 import com.wanderersoftherift.wotr.init.WotrRegistries;
 import com.wanderersoftherift.wotr.item.riftkey.EssencePredicate;
 import com.wanderersoftherift.wotr.item.riftkey.KeyForgeRecipe;
-import com.wanderersoftherift.wotr.rift.objective.ObjectiveType;
-import net.minecraft.core.Holder;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.data.PackOutput;
 import net.neoforged.neoforge.registries.DeferredHolder;
@@ -15,22 +13,26 @@ import net.neoforged.neoforge.registries.DeferredHolder;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 
-public class WotrObjectiveRecipeProvider extends KeyForgeRecipeProvider<Holder<ObjectiveType>> {
+public class WotrObjectiveRecipeProvider extends KeyForgeRecipeProvider {
 
     public WotrObjectiveRecipeProvider(PackOutput output, CompletableFuture<HolderLookup.Provider> registries) {
-        super("RiftObjectiveRecipe", output, registries, WotrRegistries.Keys.RIFT_OBJECTIVE_RECIPES,
-                LaxRegistryCodec.create(WotrRegistries.Keys.OBJECTIVES));
+        super("RiftObjectiveRecipe", output, registries);
     }
 
     @Override
-    public void generate(HolderLookup.Provider registries, Consumer<KeyForgeRecipe<Holder<ObjectiveType>>> writer) {
-        writer.accept(KeyForgeRecipe.create((Holder<ObjectiveType>) DeferredHolder
-                .create(WotrRegistries.Keys.OBJECTIVES, WanderersOfTheRift.id("kill"))).setPriority(-1).build());
+    public void generate(HolderLookup.Provider registries, Consumer<KeyForgeRecipe> writer) {
         writer.accept(KeyForgeRecipe
-                .create((Holder<ObjectiveType>) DeferredHolder.create(WotrRegistries.Keys.OBJECTIVES,
-                        WanderersOfTheRift.id("stealth")))
-                .withEssenceReq(new EssencePredicate.Builder(WanderersOfTheRift.id("dark")).setMinPercent(5f).build())
+                .create(WotrDataComponentType.RIFT_OBJECTIVE.get(),
+                        DeferredHolder.create(WotrRegistries.Keys.OBJECTIVES, WanderersOfTheRift.id("kill")))
+                .setPriority(-1)
                 .build());
+        writer.accept(
+                KeyForgeRecipe
+                        .create(WotrDataComponentType.RIFT_OBJECTIVE.get(),
+                                DeferredHolder.create(WotrRegistries.Keys.OBJECTIVES, WanderersOfTheRift.id("stealth")))
+                        .withEssenceReq(
+                                new EssencePredicate.Builder(WanderersOfTheRift.id("dark")).setMinPercent(5f).build())
+                        .build());
 
     }
 }

--- a/src/main/java/com/wanderersoftherift/wotr/datagen/WotrRiftThemeRecipeProvider.java
+++ b/src/main/java/com/wanderersoftherift/wotr/datagen/WotrRiftThemeRecipeProvider.java
@@ -6,8 +6,10 @@ import com.wanderersoftherift.wotr.init.WotrDataComponentType;
 import com.wanderersoftherift.wotr.init.WotrRegistries;
 import com.wanderersoftherift.wotr.item.riftkey.EssencePredicate;
 import com.wanderersoftherift.wotr.item.riftkey.KeyForgeRecipe;
+import net.minecraft.core.Holder;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.data.PackOutput;
+import net.minecraft.resources.ResourceLocation;
 import net.neoforged.neoforge.registries.DeferredHolder;
 
 import java.util.concurrent.CompletableFuture;
@@ -16,7 +18,8 @@ import java.util.function.Consumer;
 public class WotrRiftThemeRecipeProvider extends KeyForgeRecipeProvider {
 
     public WotrRiftThemeRecipeProvider(PackOutput output, CompletableFuture<HolderLookup.Provider> registries) {
-        super("RiftThemeRecipe", output, registries);
+        super("RiftThemeRecipe", output, registries,
+                (recipe) -> ResourceLocation.parse(((Holder<?>) recipe.getOutput()).getRegisteredName()));
     }
 
     @Override

--- a/src/main/java/com/wanderersoftherift/wotr/datagen/WotrRiftThemeRecipeProvider.java
+++ b/src/main/java/com/wanderersoftherift/wotr/datagen/WotrRiftThemeRecipeProvider.java
@@ -1,13 +1,11 @@
 package com.wanderersoftherift.wotr.datagen;
 
 import com.wanderersoftherift.wotr.WanderersOfTheRift;
-import com.wanderersoftherift.wotr.codec.LaxRegistryCodec;
 import com.wanderersoftherift.wotr.datagen.provider.KeyForgeRecipeProvider;
+import com.wanderersoftherift.wotr.init.WotrDataComponentType;
 import com.wanderersoftherift.wotr.init.WotrRegistries;
 import com.wanderersoftherift.wotr.item.riftkey.EssencePredicate;
 import com.wanderersoftherift.wotr.item.riftkey.KeyForgeRecipe;
-import com.wanderersoftherift.wotr.world.level.levelgen.theme.RiftTheme;
-import net.minecraft.core.Holder;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.data.PackOutput;
 import net.neoforged.neoforge.registries.DeferredHolder;
@@ -15,48 +13,53 @@ import net.neoforged.neoforge.registries.DeferredHolder;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 
-public class WotrRiftThemeRecipeProvider extends KeyForgeRecipeProvider<Holder<RiftTheme>> {
+public class WotrRiftThemeRecipeProvider extends KeyForgeRecipeProvider {
 
     public WotrRiftThemeRecipeProvider(PackOutput output, CompletableFuture<HolderLookup.Provider> registries) {
-        super("RiftThemeRecipe", output, registries, WotrRegistries.Keys.RIFT_THEME_RECIPES,
-                LaxRegistryCodec.create(WotrRegistries.Keys.RIFT_THEMES));
+        super("RiftThemeRecipe", output, registries);
     }
 
     @Override
-    public void generate(HolderLookup.Provider registries, Consumer<KeyForgeRecipe<Holder<RiftTheme>>> writer) {
-        writer.accept(KeyForgeRecipe.create(
-                (Holder<RiftTheme>) DeferredHolder.create(WotrRegistries.Keys.RIFT_THEMES,
-                        WanderersOfTheRift.id("cave")))
+    public void generate(HolderLookup.Provider registries, Consumer<KeyForgeRecipe> writer) {
+        writer.accept(KeyForgeRecipe
+                .create(WotrDataComponentType.RIFT_THEME.get(),
+                        DeferredHolder.create(WotrRegistries.Keys.RIFT_THEMES, WanderersOfTheRift.id("cave")))
                 .setPriority(-1)
                 .build());
         writer.accept(KeyForgeRecipe
-                .create((Holder<RiftTheme>) DeferredHolder.create(WotrRegistries.Keys.RIFT_THEMES,
-                        WanderersOfTheRift.id("forest")))
+                .create(WotrDataComponentType.RIFT_THEME.get(),
+                        DeferredHolder.create(WotrRegistries.Keys.RIFT_THEMES, WanderersOfTheRift.id("forest")))
                 .withEssenceReq(new EssencePredicate.Builder(WanderersOfTheRift.id("plant")).setMinPercent(50f).build())
                 .build());
+        writer.accept(
+                KeyForgeRecipe
+                        .create(WotrDataComponentType.RIFT_THEME.get(),
+                                DeferredHolder.create(WotrRegistries.Keys.RIFT_THEMES,
+                                        WanderersOfTheRift.id("processor")))
+                        .withEssenceReq(
+                                new EssencePredicate.Builder(WanderersOfTheRift.id("processor")).setMinPercent(1F)
+                                        .build())
+                        .build());
+        writer.accept(
+                KeyForgeRecipe
+                        .create(WotrDataComponentType.RIFT_THEME.get(),
+                                DeferredHolder.create(WotrRegistries.Keys.RIFT_THEMES,
+                                        WanderersOfTheRift.id("mushroom")))
+                        .withEssenceReq(
+                                new EssencePredicate.Builder(WanderersOfTheRift.id("mushroom")).setMinPercent(50F)
+                                        .build())
+                        .setPriority(10)
+                        .build());
         writer.accept(KeyForgeRecipe
-                .create((Holder<RiftTheme>) DeferredHolder.create(WotrRegistries.Keys.RIFT_THEMES,
-                        WanderersOfTheRift.id("processor")))
-                .withEssenceReq(
-                        new EssencePredicate.Builder(WanderersOfTheRift.id("processor")).setMinPercent(1F).build())
-                .build());
-        writer.accept(KeyForgeRecipe
-                .create((Holder<RiftTheme>) DeferredHolder.create(WotrRegistries.Keys.RIFT_THEMES,
-                        WanderersOfTheRift.id("mushroom")))
-                .withEssenceReq(
-                        new EssencePredicate.Builder(WanderersOfTheRift.id("mushroom")).setMinPercent(50F).build())
-                .setPriority(10)
-                .build());
-        writer.accept(KeyForgeRecipe
-                .create((Holder<RiftTheme>) DeferredHolder.create(WotrRegistries.Keys.RIFT_THEMES,
-                        WanderersOfTheRift.id("nether")))
+                .create(WotrDataComponentType.RIFT_THEME.get(),
+                        DeferredHolder.create(WotrRegistries.Keys.RIFT_THEMES, WanderersOfTheRift.id("nether")))
                 .withEssenceReq(
                         new EssencePredicate.Builder(WanderersOfTheRift.id("nether")).setMinPercent(50F).build())
                 .setPriority(10)
                 .build());
         writer.accept(KeyForgeRecipe
-                .create((Holder<RiftTheme>) DeferredHolder.create(WotrRegistries.Keys.RIFT_THEMES,
-                        WanderersOfTheRift.id("noir")))
+                .create(WotrDataComponentType.RIFT_THEME.get(),
+                        DeferredHolder.create(WotrRegistries.Keys.RIFT_THEMES, WanderersOfTheRift.id("noir")))
                 .withEssenceReq(
                         new EssencePredicate.Builder(WanderersOfTheRift.id("light")).setMinPercent(50F).build())
                 .setPriority(10)

--- a/src/main/java/com/wanderersoftherift/wotr/datagen/provider/KeyForgeRecipeProvider.java
+++ b/src/main/java/com/wanderersoftherift/wotr/datagen/provider/KeyForgeRecipeProvider.java
@@ -2,7 +2,6 @@ package com.wanderersoftherift.wotr.datagen.provider;
 
 import com.wanderersoftherift.wotr.init.WotrRegistries;
 import com.wanderersoftherift.wotr.item.riftkey.KeyForgeRecipe;
-import net.minecraft.core.Holder;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.data.CachedOutput;
 import net.minecraft.data.DataProvider;
@@ -17,17 +16,21 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
+import java.util.function.Function;
 
 public abstract class KeyForgeRecipeProvider implements DataProvider {
 
     private final String name;
     private final PackOutput.PathProvider pathProvider;
     private final CompletableFuture<HolderLookup.Provider> registries;
+    private final Function<KeyForgeRecipe, ResourceLocation> locationFunction;
 
-    public KeyForgeRecipeProvider(String name, PackOutput output, CompletableFuture<HolderLookup.Provider> registries) {
+    public KeyForgeRecipeProvider(String name, PackOutput output, CompletableFuture<HolderLookup.Provider> registries,
+            Function<KeyForgeRecipe, ResourceLocation> locationFunction) {
         this.name = name;
         this.pathProvider = output.createRegistryElementsPathProvider(WotrRegistries.Keys.KEY_FORGE_RECIPES);
         this.registries = registries;
+        this.locationFunction = locationFunction;
     }
 
     public abstract void generate(HolderLookup.Provider registries, Consumer<KeyForgeRecipe> writer);
@@ -38,11 +41,11 @@ public abstract class KeyForgeRecipeProvider implements DataProvider {
             Set<ResourceLocation> set = new HashSet<>();
             List<CompletableFuture<?>> list = new ArrayList<>();
             Consumer<KeyForgeRecipe> consumer = (recipe) -> {
-                Holder<?> holder = (Holder<?>) recipe.getOutput();
-                if (!set.add(ResourceLocation.parse(holder.getRegisteredName()))) {
-                    throw new IllegalStateException("Duplicate recipe " + holder.getRegisteredName());
+                ResourceLocation location = locationFunction.apply(recipe);
+                if (!set.add(location)) {
+                    throw new IllegalStateException("Duplicate recipe " + location);
                 } else {
-                    Path path = this.pathProvider.json(ResourceLocation.parse(holder.getRegisteredName()));
+                    Path path = this.pathProvider.json(location);
                     list.add(
                             DataProvider.saveStable(output, provider, KeyForgeRecipe.codec(), recipe, path));
                 }

--- a/src/main/java/com/wanderersoftherift/wotr/datagen/provider/KeyForgeRecipeProvider.java
+++ b/src/main/java/com/wanderersoftherift/wotr/datagen/provider/KeyForgeRecipeProvider.java
@@ -1,14 +1,12 @@
 package com.wanderersoftherift.wotr.datagen.provider;
 
-import com.mojang.serialization.Codec;
+import com.wanderersoftherift.wotr.init.WotrRegistries;
 import com.wanderersoftherift.wotr.item.riftkey.KeyForgeRecipe;
 import net.minecraft.core.Holder;
 import net.minecraft.core.HolderLookup;
-import net.minecraft.core.Registry;
 import net.minecraft.data.CachedOutput;
 import net.minecraft.data.DataProvider;
 import net.minecraft.data.PackOutput;
-import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import org.jetbrains.annotations.NotNull;
 
@@ -20,35 +18,33 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 
-public abstract class KeyForgeRecipeProvider<T extends Holder<?>> implements DataProvider {
+public abstract class KeyForgeRecipeProvider implements DataProvider {
 
     private final String name;
     private final PackOutput.PathProvider pathProvider;
     private final CompletableFuture<HolderLookup.Provider> registries;
-    private final Codec<T> outputCodec;
 
-    public KeyForgeRecipeProvider(String name, PackOutput output, CompletableFuture<HolderLookup.Provider> registries,
-            ResourceKey<? extends Registry<KeyForgeRecipe<T>>> outputRegistryKey, Codec<T> outputCodec) {
+    public KeyForgeRecipeProvider(String name, PackOutput output, CompletableFuture<HolderLookup.Provider> registries) {
         this.name = name;
-        this.pathProvider = output.createRegistryElementsPathProvider(outputRegistryKey);
+        this.pathProvider = output.createRegistryElementsPathProvider(WotrRegistries.Keys.KEY_FORGE_RECIPES);
         this.registries = registries;
-        this.outputCodec = outputCodec;
     }
 
-    public abstract void generate(HolderLookup.Provider registries, Consumer<KeyForgeRecipe<T>> writer);
+    public abstract void generate(HolderLookup.Provider registries, Consumer<KeyForgeRecipe> writer);
 
     @Override
     public @NotNull CompletableFuture<?> run(@NotNull CachedOutput output) {
         return this.registries.thenCompose(provider -> {
             Set<ResourceLocation> set = new HashSet<>();
             List<CompletableFuture<?>> list = new ArrayList<>();
-            Consumer<KeyForgeRecipe<T>> consumer = (recipe) -> {
-                if (!set.add(ResourceLocation.parse(recipe.getOutput().getRegisteredName()))) {
-                    throw new IllegalStateException("Duplicate recipe " + recipe.getOutput().getRegisteredName());
+            Consumer<KeyForgeRecipe> consumer = (recipe) -> {
+                Holder<?> holder = (Holder<?>) recipe.getOutput();
+                if (!set.add(ResourceLocation.parse(holder.getRegisteredName()))) {
+                    throw new IllegalStateException("Duplicate recipe " + holder.getRegisteredName());
                 } else {
-                    Path path = this.pathProvider.json(ResourceLocation.parse(recipe.getOutput().getRegisteredName()));
+                    Path path = this.pathProvider.json(ResourceLocation.parse(holder.getRegisteredName()));
                     list.add(
-                            DataProvider.saveStable(output, provider, KeyForgeRecipe.codec(outputCodec), recipe, path));
+                            DataProvider.saveStable(output, provider, KeyForgeRecipe.codec(), recipe, path));
                 }
             };
 

--- a/src/main/java/com/wanderersoftherift/wotr/init/WotrDataComponentType.java
+++ b/src/main/java/com/wanderersoftherift/wotr/init/WotrDataComponentType.java
@@ -9,11 +9,14 @@ import com.wanderersoftherift.wotr.item.implicit.GearImplicits;
 import com.wanderersoftherift.wotr.item.riftkey.RiftConfig;
 import com.wanderersoftherift.wotr.item.runegem.RunegemData;
 import com.wanderersoftherift.wotr.item.socket.GearSockets;
+import com.wanderersoftherift.wotr.rift.objective.ObjectiveType;
+import com.wanderersoftherift.wotr.world.level.levelgen.theme.RiftTheme;
 import net.minecraft.core.Holder;
 import net.minecraft.core.UUIDUtil;
 import net.minecraft.core.component.DataComponentType;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
 import net.neoforged.neoforge.registries.DeferredHolder;
 import net.neoforged.neoforge.registries.DeferredRegister;
@@ -41,8 +44,15 @@ public class WotrDataComponentType {
             "ability", AbstractAbility.CODEC, AbstractAbility.STREAM_CODEC);
     public static final DeferredHolder<DataComponentType<?>, DataComponentType<AbilityUpgradePool>> ABILITY_UPGRADE_POOL = register(
             "ability_upgrade_pool", AbilityUpgradePool.CODEC, AbilityUpgradePool.STREAM_CODEC);
+
     public static final DeferredHolder<DataComponentType<?>, DataComponentType<RiftConfig>> RIFT_CONFIG = register(
             "rift_config", RiftConfig.CODEC, RiftConfig.STREAM_CODEC);
+    public static final DeferredHolder<DataComponentType<?>, DataComponentType<Holder<RiftTheme>>> RIFT_THEME = register(
+            "rift_theme", RiftTheme.CODEC, RiftTheme.STREAM_CODEC);
+    public static final DeferredHolder<DataComponentType<?>, DataComponentType<Holder<ObjectiveType>>> RIFT_OBJECTIVE = register(
+            "rift_objective", ObjectiveType.CODEC, ObjectiveType.STREAM_CODEC);
+    public static final DeferredHolder<DataComponentType<?>, DataComponentType<Integer>> RIFT_SEED = register(
+            "rift_seed", Codec.INT, ByteBufCodecs.INT);
 
     private static <T> DeferredHolder<DataComponentType<?>, DataComponentType<T>> register(
             String name,

--- a/src/main/java/com/wanderersoftherift/wotr/init/WotrRegistries.java
+++ b/src/main/java/com/wanderersoftherift/wotr/init/WotrRegistries.java
@@ -18,9 +18,7 @@ import com.wanderersoftherift.wotr.rift.objective.OngoingObjective;
 import com.wanderersoftherift.wotr.world.level.levelgen.processor.input.InputBlockState;
 import com.wanderersoftherift.wotr.world.level.levelgen.processor.output.OutputBlockState;
 import com.wanderersoftherift.wotr.world.level.levelgen.theme.RiftTheme;
-import net.minecraft.core.Holder;
 import net.minecraft.core.Registry;
-import net.minecraft.resources.RegistryFixedCodec;
 import net.minecraft.resources.ResourceKey;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
@@ -68,10 +66,8 @@ public class WotrRegistries {
                 .createRegistryKey(WanderersOfTheRift.id("modifier"));
         public static final ResourceKey<Registry<ObjectiveType>> OBJECTIVES = ResourceKey
                 .createRegistryKey(WanderersOfTheRift.id("objective"));
-        public static final ResourceKey<Registry<KeyForgeRecipe<Holder<ObjectiveType>>>> RIFT_OBJECTIVE_RECIPES = ResourceKey
-                .createRegistryKey(WanderersOfTheRift.id("rift_objective_recipe"));
-        public static final ResourceKey<Registry<KeyForgeRecipe<Holder<RiftTheme>>>> RIFT_THEME_RECIPES = ResourceKey
-                .createRegistryKey(WanderersOfTheRift.id("rift_theme_recipe"));
+        public static final ResourceKey<Registry<KeyForgeRecipe>> KEY_FORGE_RECIPES = ResourceKey
+                .createRegistryKey(WanderersOfTheRift.id("key_forge_recipe"));
         public static final ResourceKey<Registry<RunegemData>> RUNEGEM_DATA = ResourceKey
                 .createRegistryKey(WanderersOfTheRift.id("runegem_data"));
         public static final ResourceKey<Registry<MapCodec<? extends AbstractEffect>>> EFFECTS = ResourceKey
@@ -121,12 +117,7 @@ public class WotrRegistries {
         event.dataPackRegistry(Keys.ABILITY_UPGRADES, AbilityUpgrade.CODEC, AbilityUpgrade.CODEC);
         event.dataPackRegistry(Keys.EFFECT_MARKERS, EffectMarker.CODEC, EffectMarker.CODEC);
         event.dataPackRegistry(Keys.ABILITIES, AbstractAbility.DIRECT_CODEC, AbstractAbility.DIRECT_CODEC);
-        event.dataPackRegistry(Keys.RIFT_THEME_RECIPES,
-                KeyForgeRecipe.codec(RegistryFixedCodec.create(Keys.RIFT_THEMES)),
-                KeyForgeRecipe.codec(RegistryFixedCodec.create(Keys.RIFT_THEMES)));
+        event.dataPackRegistry(Keys.KEY_FORGE_RECIPES, KeyForgeRecipe.codec(), KeyForgeRecipe.codec());
         event.dataPackRegistry(Keys.OBJECTIVES, ObjectiveType.DIRECT_CODEC, ObjectiveType.DIRECT_CODEC);
-        event.dataPackRegistry(Keys.RIFT_OBJECTIVE_RECIPES,
-                KeyForgeRecipe.codec(RegistryFixedCodec.create(Keys.OBJECTIVES)),
-                KeyForgeRecipe.codec(RegistryFixedCodec.create(Keys.OBJECTIVES)));
     }
 }

--- a/src/main/java/com/wanderersoftherift/wotr/item/riftkey/RiftConfig.java
+++ b/src/main/java/com/wanderersoftherift/wotr/item/riftkey/RiftConfig.java
@@ -58,6 +58,11 @@ public record RiftConfig(int tier, Optional<Holder<RiftTheme>> theme, Optional<H
         this(tier, Optional.of(theme), Optional.empty(), Optional.of(seed));
     }
 
+    /**
+     * @deprecated Rather than having RiftConfig on an item should migrate to using individual data components
+     * @return Components to add to the tooltip
+     */
+    @Deprecated
     public List<Component> getTooltips() {
         List<Component> result = new ArrayList<>();
         result.add(Component.translatable("tooltip." + WanderersOfTheRift.MODID + ".rift_key_tier", tier)

--- a/src/main/java/com/wanderersoftherift/wotr/item/riftkey/RiftKey.java
+++ b/src/main/java/com/wanderersoftherift/wotr/item/riftkey/RiftKey.java
@@ -7,9 +7,14 @@ import com.wanderersoftherift.wotr.entity.portal.RiftPortalEntranceEntity;
 import com.wanderersoftherift.wotr.init.WotrDataComponentType;
 import com.wanderersoftherift.wotr.init.WotrEntities;
 import com.wanderersoftherift.wotr.init.WotrSoundEvents;
+import com.wanderersoftherift.wotr.rift.objective.ObjectiveType;
+import com.wanderersoftherift.wotr.world.level.levelgen.theme.RiftTheme;
+import net.minecraft.ChatFormatting;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.core.Holder;
 import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.item.Item;
@@ -76,6 +81,34 @@ public class RiftKey extends Item {
         RiftConfig riftConfig = stack.get(WotrDataComponentType.RIFT_CONFIG);
         if (riftConfig != null) {
             components.addAll(riftConfig.getTooltips());
+            return;
+        }
+
+        int tier = stack.getOrDefault(WotrDataComponentType.ITEM_RIFT_TIER, 0);
+        components.add(Component.translatable("tooltip." + WanderersOfTheRift.MODID + ".rift_key_tier", tier)
+                .withColor(ChatFormatting.GRAY.getColor()));
+
+        Holder<RiftTheme> riftTheme = stack.get(WotrDataComponentType.RIFT_THEME);
+        if (riftTheme != null) {
+            ResourceLocation themeId = ResourceLocation.parse(riftTheme.getRegisteredName());
+            Component themeName = Component
+                    .translatable("rift_theme." + themeId.getNamespace() + "." + themeId.getPath());
+            components.add(Component.translatable("tooltip." + WanderersOfTheRift.MODID + ".rift_key_theme", themeName)
+                    .withColor(ChatFormatting.GRAY.getColor()));
+        }
+        Holder<ObjectiveType> objective = stack.get(WotrDataComponentType.RIFT_OBJECTIVE);
+        if (objective != null) {
+            ResourceLocation objectiveLoc = ResourceLocation.parse(objective.getRegisteredName());
+            Component objectiveName = Component
+                    .translatable("objective." + objectiveLoc.getNamespace() + "." + objectiveLoc.getPath() + ".name");
+            components.add(
+                    Component.translatable("tooltip." + WanderersOfTheRift.MODID + ".rift_key_objective", objectiveName)
+                            .withColor(ChatFormatting.GRAY.getColor()));
+        }
+        Integer seed = stack.get(WotrDataComponentType.RIFT_SEED);
+        if (seed != null) {
+            components.add(Component.translatable(WanderersOfTheRift.translationId("tooltip", "rift_key_seed"), seed)
+                    .withColor(ChatFormatting.GRAY.getColor()));
         }
     }
 
@@ -89,10 +122,21 @@ public class RiftKey extends Item {
         rift.setPos(pos);
         rift.setYRot(dir.toYRot());
         rift.setBillboard(dir.getAxis().isVertical());
-        if (riftKey.has(WotrDataComponentType.RIFT_CONFIG)) {
-            rift.setRiftConfig(riftKey.get(WotrDataComponentType.RIFT_CONFIG));
-        }
+        rift.setRiftConfig(generateConfig(riftKey));
         level.addFreshEntity(rift);
         rift.playSound(WotrSoundEvents.RIFT_OPEN.value());
+    }
+
+    private RiftConfig generateConfig(ItemStack stack) {
+        RiftConfig riftConfig = stack.get(WotrDataComponentType.RIFT_CONFIG);
+        if (riftConfig != null) {
+            return riftConfig;
+        }
+        int tier = stack.getOrDefault(WotrDataComponentType.ITEM_RIFT_TIER, 0);
+        Holder<RiftTheme> riftTheme = stack.get(WotrDataComponentType.RIFT_THEME);
+        Holder<ObjectiveType> objective = stack.get(WotrDataComponentType.RIFT_OBJECTIVE);
+        Integer seed = stack.get(WotrDataComponentType.RIFT_SEED);
+        return new RiftConfig(tier, Optional.ofNullable(riftTheme), Optional.ofNullable(objective),
+                Optional.ofNullable(seed));
     }
 }

--- a/src/main/java/com/wanderersoftherift/wotr/rift/objective/ObjectiveType.java
+++ b/src/main/java/com/wanderersoftherift/wotr/rift/objective/ObjectiveType.java
@@ -2,9 +2,12 @@ package com.wanderersoftherift.wotr.rift.objective;
 
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.MapCodec;
+import com.wanderersoftherift.wotr.codec.LaxRegistryCodec;
 import com.wanderersoftherift.wotr.init.WotrRegistries;
 import net.minecraft.core.Holder;
-import net.minecraft.resources.RegistryFixedCodec;
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.codec.ByteBufCodecs;
+import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.world.level.LevelAccessor;
 
 import java.util.function.Function;
@@ -15,7 +18,9 @@ import java.util.function.Function;
 public interface ObjectiveType {
     Codec<ObjectiveType> DIRECT_CODEC = WotrRegistries.OBJECTIVE_TYPES.byNameCodec()
             .dispatch(ObjectiveType::getCodec, Function.identity());
-    Codec<Holder<ObjectiveType>> CODEC = RegistryFixedCodec.create(WotrRegistries.Keys.OBJECTIVES);
+    Codec<Holder<ObjectiveType>> CODEC = LaxRegistryCodec.create(WotrRegistries.Keys.OBJECTIVES);
+    StreamCodec<RegistryFriendlyByteBuf, Holder<ObjectiveType>> STREAM_CODEC = ByteBufCodecs
+            .holderRegistry(WotrRegistries.Keys.OBJECTIVES);
 
     /**
      * @return A codec for the objective type implementation

--- a/src/main/java/com/wanderersoftherift/wotr/world/level/levelgen/theme/RiftTheme.java
+++ b/src/main/java/com/wanderersoftherift/wotr/world/level/levelgen/theme/RiftTheme.java
@@ -3,9 +3,12 @@ package com.wanderersoftherift.wotr.world.level.levelgen.theme;
 import com.mojang.datafixers.util.Pair;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
+import com.wanderersoftherift.wotr.codec.LaxRegistryCodec;
 import com.wanderersoftherift.wotr.init.WotrRegistries;
 import net.minecraft.core.Holder;
-import net.minecraft.resources.RegistryFixedCodec;
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.codec.ByteBufCodecs;
+import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessor;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessorList;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessorType;
@@ -27,7 +30,10 @@ public record RiftTheme(Map<ThemePieceType, Holder<StructureProcessorList>> proc
 
     public static final Codec<RiftTheme> DIRECT_SYNC_CODEC = Codec.unit(RiftTheme::new);
 
-    public static final Codec<Holder<RiftTheme>> CODEC = RegistryFixedCodec.create(WotrRegistries.Keys.RIFT_THEMES);
+    public static final Codec<Holder<RiftTheme>> CODEC = LaxRegistryCodec.create(WotrRegistries.Keys.RIFT_THEMES);
+
+    public static final StreamCodec<RegistryFriendlyByteBuf, Holder<RiftTheme>> STREAM_CODEC = ByteBufCodecs
+            .holderRegistry(WotrRegistries.Keys.RIFT_THEMES);
 
     public RiftTheme() {
         this(Map.of());


### PR DESCRIPTION
### Summary

This PR updates key forge recipes to use a unified system, such that there are no longer separate recipe types for objectives and rift themes. Instead Key Forge Recipes apply data components to the key, and the type of data component is specified in the recipe. The key forge finds the highest priority usable recipe for each data component to apply.

This change sets up for easier integration with REI or similar, as it reduces the number of recipes and provides a generic way to show the result (apply the output to a blank key).

As part of this change, the elements of RiftConfig are split into separate Data Components which are combined when opening a rift. Backwards compatibility to existing keys using a RiftConfig DataComponent has been maintained but is deprecated.
