### PR TITLE
Ability TeleportEffect position changes + Blink ability

### DIFF
--- a/src/generated/resources/assets/wotr/lang/en_us.json
+++ b/src/generated/resources/assets/wotr/lang/en_us.json
@@ -1,6 +1,7 @@
 {
   "ability.wotr.cannot_unlock": "You must unlock the following to get this boost: ",
   "ability.wotr.dash": "Dash",
+  "ability.wotr.dash_blink": "Blink",
   "ability.wotr.fireball_ability": "Fireball",
   "ability.wotr.firetouch": "Nonsense Experimental Ability",
   "ability.wotr.heal": "Heal",

--- a/src/main/java/com/wanderersoftherift/wotr/abilities/effects/util/PositionInfo.java
+++ b/src/main/java/com/wanderersoftherift/wotr/abilities/effects/util/PositionInfo.java
@@ -1,0 +1,82 @@
+package com.wanderersoftherift.wotr.abilities.effects.util;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.MapCodec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import net.minecraft.commands.CommandSource;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.arguments.coordinates.LocalCoordinates;
+import net.minecraft.network.chat.Component;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.util.StringRepresentable;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.phys.Vec2;
+import net.minecraft.world.phys.Vec3;
+
+public record PositionInfo(Vec3 position, Mode mode) {
+	public enum Mode implements StringRepresentable {
+		// Following Minecraft's naming conventions for position modes
+		// Relative is just relative to the entity's world position
+		RELATIVE("relative", 0),
+		// World is basically the global position
+		WORLD("world", 1),
+		// Local is relative to the entity's looking direction
+		LOCAL("local", 2);
+
+		private final String name;
+		private final int id;
+
+		public static final Codec<Mode> CODEC = StringRepresentable.fromEnum(Mode::values);
+
+		Mode(String name, int id) {
+			this.name = name;
+			this.id = id;
+		}
+
+		public String getName() {
+			return this.name;
+		}
+
+		public int getId() {
+			return this.id;
+		}
+
+		@Override
+		public String getSerializedName() {
+			return this.getName();
+		}
+	}
+
+	public static final MapCodec<PositionInfo> CODEC = RecordCodecBuilder.mapCodec(
+			instance -> instance.group(
+					Vec3.CODEC.fieldOf("values").forGetter(PositionInfo::position),
+					Mode.CODEC.optionalFieldOf("mode", Mode.LOCAL).forGetter(PositionInfo::mode)
+			).apply(instance, PositionInfo::new)
+	);
+
+	@Override
+	public Vec3 position() {
+		return position;
+	}
+
+	public Vec3 worldPosition(Entity entity) {
+		switch (mode) {
+			case RELATIVE -> {
+				return entity.position().add(position);
+			}
+			case WORLD -> {
+				return position;
+			}
+			case LOCAL -> {
+				LocalCoordinates coordinates = new LocalCoordinates(position.x, position.y, position.z);
+				return coordinates.getPosition(new CommandSourceStack(CommandSource.NULL, entity.position(), new Vec2(entity.getXRot(), entity.getYRot()), (ServerLevel) entity.level(), 0, "", Component.empty(), entity.level().getServer(), entity));
+			}
+		}
+		return position;
+	}
+
+	@Override
+	public Mode mode() {
+		return mode;
+	}
+}

--- a/src/main/java/com/wanderersoftherift/wotr/abilities/effects/util/TeleportInfo.java
+++ b/src/main/java/com/wanderersoftherift/wotr/abilities/effects/util/TeleportInfo.java
@@ -16,26 +16,19 @@ import java.util.function.IntFunction;
 public class TeleportInfo {
     public static final MapCodec<TeleportInfo> CODEC = RecordCodecBuilder.mapCodec(instance -> instance
             .group(TeleportTarget.CODEC.fieldOf("teleport_target").forGetter(TeleportInfo::getTarget),
-                    Vec3.CODEC.fieldOf("position").forGetter(TeleportInfo::getPosition),
-                    Codec.BOOL.optionalFieldOf("relative").forGetter(TeleportInfo::isRelative)
+                    PositionInfo.CODEC.fieldOf("position_info").forGetter(TeleportInfo::getPositionInfo)
             ).apply(instance, TeleportInfo::new));
 
     private final TeleportTarget target;
-    private final Vec3 position;
-    private final Optional<Boolean> isRelative;
+    private final PositionInfo positionInfo;
 
-    public TeleportInfo(TeleportTarget target, Vec3 position, Optional<Boolean> isRelative) {
+    public TeleportInfo(TeleportTarget target, PositionInfo positionInfo) {
         this.target = target;
-        this.position = position;
-        this.isRelative = isRelative;
+        this.positionInfo = positionInfo;
     }
 
-    public Optional<Boolean> isRelative() {
-        return this.isRelative;
-    }
-
-    public Vec3 getPosition() {
-        return position;
+    public PositionInfo getPositionInfo() {
+        return this.positionInfo;
     }
 
     public TeleportTarget getTarget() {

--- a/src/main/java/com/wanderersoftherift/wotr/datagen/WotrLanguageProvider.java
+++ b/src/main/java/com/wanderersoftherift/wotr/datagen/WotrLanguageProvider.java
@@ -164,6 +164,7 @@ public class WotrLanguageProvider extends LanguageProvider {
         add("ability." + WanderersOfTheRift.MODID + ".icicles_ability", "Icicles");
         add("ability." + WanderersOfTheRift.MODID + ".mega_boost", "Mega Boost");
         add("ability." + WanderersOfTheRift.MODID + ".dash", "Dash");
+        add("ability." + WanderersOfTheRift.MODID + ".dash_blink", "Blink");
         add("ability." + WanderersOfTheRift.MODID + ".summon_skeletons", "Summon Skeletons");
         add("ability." + WanderersOfTheRift.MODID + ".test_ability", "Test Ability");
         add("ability." + WanderersOfTheRift.MODID + ".knockback", "Knockback");

--- a/src/main/resources/data/wotr/wotr/abilities/dash_blink.json
+++ b/src/main/resources/data/wotr/wotr/abilities/dash_blink.json
@@ -1,0 +1,69 @@
+{
+  "type": "wotr:standard_ability",
+  "ability_name": "wotr:dash_blink",
+  "cooldown": 150,
+  "effects": [
+    {
+      "type": "wotr:teleport_effect",
+      "targeting": {
+        "type": "wotr:self_targeting"
+      },
+      "tele_info": {
+        "teleport_target": "user",
+        "position_info": {
+          "values": [
+            0.0, 0.0, 3.5
+          ],
+          "mode": "local"
+        },
+        "reset_fall_distance": true,
+        "ignore_walls": false
+      }
+    },
+    {
+      "type": "wotr:movement_effect",
+      "targeting": {
+        "type": "wotr:self_targeting"
+      },
+      "velocity": [
+        0.0,
+        0.04,
+        0.2
+      ]
+    },
+    {
+      "type": "wotr:sound_effect",
+      "sound": {
+        "sound_id": "minecraft:entity.ender_eye.death"
+      },
+      "targeting": {
+        "type": "wotr:self_targeting"
+      }
+    },
+    {
+      "type": "wotr:sound_effect",
+      "sound": {
+        "sound_id": "minecraft:entity.player.teleport"
+      },
+      "targeting": {
+        "type": "wotr:self_targeting"
+      }
+    },
+    {
+      "type": "wotr:status_effect",
+      "status_effect": {
+        "id": "minecraft:slowness",
+        "amplifier": 1,
+        "duration": 30,
+        "ambient": false,
+        "show_particles": false,
+        "show_icon": true
+      },
+      "targeting": {
+        "type": "wotr:self_targeting"
+      }
+    }
+  ],
+  "icon": "minecraft:textures/item/ender_pearl.png",
+  "mana_cost": 15
+}


### PR DESCRIPTION
## PositionInfo
Created a PositionInfo class for use in the abilities. 
It has 2 properties, being: "values" and "mode"
- The "values" property is just a Vec3.
- The "mode" property is an Enum for selecting which positioning mode to use. The modes are RELATIVE (relative to the entity's position), WORLD (a global position) and LOCAL (relative to where the entity is looking)
It also has a function worldPosition(Entity). It uses the mode to get the world position from the values and mode.

## Blink
Simple ability that uses the PositionInfo changes added to the TeleportEffect to make a new dash variation that teleports the player through blocks. I didn't add a way to get it without commands for now.