### PR TITLE
fix: (#205) improve dash

### DIFF
--- a/src/main/resources/data/wotr/wotr/abilities/dash.json
+++ b/src/main/resources/data/wotr/wotr/abilities/dash.json
@@ -10,9 +10,21 @@
       },
       "velocity": [
         0.0,
-        0.4000000059604645,
+        0.0,
         1.0
       ]
+    },
+    {
+      "type": "wotr:movement_effect",
+      "targeting": {
+        "type": "wotr:self_targeting"
+      },
+      "velocity": [
+        0.0,
+        0.4,
+        0.0
+      ],
+      "relativeFrame": "absolute"
     },
     {
       "type": "wotr:sound_effect",


### PR DESCRIPTION
This addresses an issue where the vertical component of dash movement was being rotated by the player's look pitch, resulting in more vertical or even backwards movement when the player looked upwards.

Closes #205 