### PR TITLE
fix: (#239) spawnPieces command

### DIFF
--- a/src/main/java/com/wanderersoftherift/wotr/core/rift/RiftData.java
+++ b/src/main/java/com/wanderersoftherift/wotr/core/rift/RiftData.java
@@ -50,9 +50,6 @@ public class RiftData extends SavedData { // TODO: split this
     }
 
     public static RiftData get(ServerLevel level) {
-        if (!RiftLevelManager.isRift(level)) {
-            throw new IllegalArgumentException("Not a rift level");
-        }
         return level.getDataStorage()
                 .computeIfAbsent(factory(level.getServer().overworld().dimension(),
                         level.getServer().overworld().getSharedSpawnPos(), new RiftConfig(0)), "rift_data");


### PR DESCRIPTION
Remove a check that a level is a rift when fetching RiftData that prevents spawnPiece withPOIs/withPOIsAndTheme from working.

Closes #239 