### PR TITLE
Simple Change to Jigsaw keybinding

### DIFF
--- a/src/generated/resources/assets/wotr/lang/en_us.json
+++ b/src/generated/resources/assets/wotr/lang/en_us.json
@@ -353,6 +353,7 @@
   "key.wotr.ability.use_selected": "Use Selected Ability",
   "key.wotr.categories.ability": "Abilities",
   "key.wotr.categories.misc": "Wanderers of the Rift: Misc",
+  "key.wotr.jigsaw_name_toggle": "Show Jigsaw Block Info",
   "key.wotr.tooltip.show_tooltip_info": "Show Additional Tooltip Info",
   "keybinds.wotr.l_alt": "LAlt",
   "keybinds.wotr.l_ctrl": "LCtrl",

--- a/src/main/java/com/wanderersoftherift/wotr/datagen/WotrLanguageProvider.java
+++ b/src/main/java/com/wanderersoftherift/wotr/datagen/WotrLanguageProvider.java
@@ -272,6 +272,7 @@ public class WotrLanguageProvider extends LanguageProvider {
         add(WotrKeyMappings.NEXT_ABILITY_KEY.getName(), "Select Next Ability");
         add(WotrKeyMappings.USE_ABILITY_KEY.getName(), "Use Selected Ability");
         add(WotrKeyMappings.SHOW_TOOLTIP_INFO.getName(), "Show Additional Tooltip Info");
+        add(WotrKeyMappings.JIGSAW_NAME_TOGGLE_KEY.getName(), "Show Jigsaw Block Info");
 
         add(WanderersOfTheRift.translationId("keybinds", "l_alt"), "LAlt");
         add(WanderersOfTheRift.translationId("keybinds", "r_alt"), "RAlt");

--- a/src/main/java/com/wanderersoftherift/wotr/init/client/WotrKeyMappings.java
+++ b/src/main/java/com/wanderersoftherift/wotr/init/client/WotrKeyMappings.java
@@ -66,8 +66,8 @@ public class WotrKeyMappings {
             InputConstants.Type.KEYSYM, GLFW.GLFW_KEY_LEFT_SHIFT, MISC_CATEGORY);
 
     public static final KeyMapping JIGSAW_NAME_TOGGLE_KEY = new KeyMapping(
-            "key." + WanderersOfTheRift.id("jigsaw_name_toggle"), InputConstants.Type.KEYSYM, GLFW.GLFW_KEY_UNKNOWN,
-            "key.categories.misc");
+            WanderersOfTheRift.translationId("key", "jigsaw_name_toggle"), KeyConflictContext.IN_GAME,
+            InputConstants.Type.KEYSYM, GLFW.GLFW_KEY_UNKNOWN, MISC_CATEGORY);
 
     @SubscribeEvent
     public static void registerKeys(RegisterKeyMappingsEvent event) {
@@ -78,7 +78,6 @@ public class WotrKeyMappings {
         event.register(NEXT_ABILITY_KEY);
         event.register(USE_ABILITY_KEY);
         event.register(SHOW_TOOLTIP_INFO);
-
         event.register(JIGSAW_NAME_TOGGLE_KEY);
     }
 


### PR DESCRIPTION
Fixes https://github.com/Dimension-Delvers/submit-feedback/issues/67

updates KeyMapping class to align how the Jigsaw keybind is initialized and allow it to save the keybind as expected between game launches

Also adds a translation for the option.